### PR TITLE
Only set network operator when not on wifi

### DIFF
--- a/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
@@ -66,7 +66,6 @@ public class FcmMessagingService extends FirebaseMessagingService {
         mRemoteLogger.d("onMessageReceived");
         Map<String, String> data = remoteMessage.getData();
         String requestType = data.get(MESSAGE_TYPE);
-        int attempt = Integer.parseInt(data.get(ATTEMPT));
 
         LogHelper.using(mRemoteLogger).logMiddlewareMessageReceived(remoteMessage, requestType);
 
@@ -100,6 +99,7 @@ public class FcmMessagingService extends FirebaseMessagingService {
             }
 
             if (!connectionSufficient) {
+                int attempt = Integer.parseInt(data.get(ATTEMPT));
                 if (attempt >= MAX_MIDDLEWARE_PUSH_ATTEMPTS) {
                     VialerStatistics.incomingCallFailedDueToInsufficientNetwork(remoteMessage);
                 }

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
@@ -75,6 +75,7 @@ public class SipCall extends org.pjsip.pjsua2.Call {
     private boolean mIpChangeInProgress = false;
     private String mMiddlewareKey;
     private String mMessageStartTime;
+    private CallInfo mLastCallInfo;
 
     public static final String CALL_DIRECTION_OUTGOING = "outgoing";
     public static final String CALL_DIRECTION_INCOMING = "incoming";
@@ -304,8 +305,9 @@ public class SipCall extends org.pjsip.pjsua2.Call {
     @Override
     public void onCallState(OnCallStateParam onCallStateParam) {
         try {
-            CallInfo info = getInfo();  // Check to see if we can get CallInfo with this callback.
-            pjsip_inv_state callState = info.getState();
+            mLastCallInfo = getInfo();  // Check to see if we can get CallInfo with this callback.
+
+            pjsip_inv_state callState = mLastCallInfo.getState();
             mRemoteLogger.e("CallState changed!");
             mRemoteLogger.e(callState.toString());
 
@@ -573,12 +575,9 @@ public class SipCall extends org.pjsip.pjsua2.Call {
     }
 
     public String getAsteriskCallId() {
-        try {
-            return getInfo().getCallIdString();
-        } catch (Exception e) {
-            mRemoteLogger.e("Unable to get call id: " + e.getMessage());
-            return null;
-        }
+        CallInfo callInfo = getLastCallInfo();
+
+        return callInfo != null ? callInfo.getCallIdString() : null;
     }
 
     public String getCallDirection() {
@@ -591,15 +590,43 @@ public class SipCall extends org.pjsip.pjsua2.Call {
      */
     public String getTransport() {
         try {
-            String transport = getInfo().getLocalContact();
+            CallInfo callInfo = getLastCallInfo();
 
-            if (transport == null) return null;
+            if (callInfo == null) {
+                return null;
+            }
 
-            if (!transport.contains("transport")) return null;
+            String transport = callInfo.getLocalContact();
+
+            if (transport == null) {
+                return null;
+            }
+
+            if (!transport.contains("transport")) {
+                return null;
+            }
 
             return StringUtil.extractFirstCaptureGroupFromString(transport, "transport=([^;]+);");
         } catch (Exception e) {
             mRemoteLogger.e("Unable to get call id: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Will return the last callinfo recovered during call state change, if no c
+     *
+     * @return
+     */
+    private @Nullable CallInfo getLastCallInfo() {
+        try {
+            if (mLastCallInfo == null) {
+                mLastCallInfo = getInfo();
+            }
+
+            return mLastCallInfo;
+        } catch (Exception e) {
+            mRemoteLogger.e("Unable to get call info");
             return null;
         }
     }

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
@@ -614,7 +614,7 @@ public class SipCall extends org.pjsip.pjsua2.Call {
     }
 
     /**
-     * Will return the last callinfo recovered during call state change, if no c
+     * Will return the last callinfo recovered during call state change, if no lastCallInfo exists, it will attempt to retrieve it.
      *
      * @return
      */

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -41,6 +41,7 @@ import static com.voipgrid.vialer.statistics.StatsConstants
         .VALUE_FAILED_REASON_ORIGINATOR_CANCELLED;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_HANGUP_REASON_REMOTE;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_HANGUP_REASON_USER;
+import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_NETWORK_WIFI;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_OS;
 
 import android.content.Context;
@@ -243,7 +244,9 @@ public class VialerStatistics {
         addValue(KEY_APP_VERSION, mDefaultDataProvider.getAppVersion());
         addValue(KEY_APP_STATUS, mDefaultDataProvider.getAppStatus());
         addValue(KEY_NETWORK, mDefaultDataProvider.getNetwork());
-        addValue(KEY_NETWORK_OPERATOR, mDefaultDataProvider.getNetworkOperator());
+        if (!mDefaultDataProvider.getNetwork().equals(VALUE_NETWORK_WIFI)) {
+            addValue(KEY_NETWORK_OPERATOR, mDefaultDataProvider.getNetworkOperator());
+        }
         addValue(KEY_CLIENT_COUNTRY, mDefaultDataProvider.getClientCountry());
         addValue(KEY_SIP_USER_ID, mDefaultDataProvider.getSipUserId());
 


### PR DESCRIPTION
Fixed a few issues:

- Resolved #11 
- Properly converting the timestamp from the middleware so we can get the correct time_to_initial_response
- Fixed an error when attempting to get "attempt" from a non-call fcm message
- Fixed a crash when getting the callinfo after the call has ended