### PR TITLE
VIALA-851/847: Metrics for failed incoming calls

### DIFF
--- a/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
@@ -185,7 +185,7 @@ public class FcmMessagingService extends FirebaseMessagingService {
 
     /**
      * @param phoneNumber the number that tried call in.
-     * @param callerId pretty name of the phonenumber that tied to call in.
+     * @param callerId pretty name of the phonenumber that tried to call in.
      * @param messageStartTime message roundtrip throughput timestamp handled as String for logging
      *                         purposes.
      */

--- a/app/src/main/java/com/voipgrid/vialer/logging/sip/SipLogHandler.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/sip/SipLogHandler.java
@@ -1,17 +1,25 @@
 package com.voipgrid.vialer.logging.sip;
 
 import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
 
 import com.voipgrid.vialer.VialerApplication;
+import com.voipgrid.vialer.util.StringUtil;
+
+import java.util.ArrayList;
 
 /**
  * Performs various actions based on the result of the pjsip logs.
  */
 public class SipLogHandler {
 
-    private static final String  NETWORK_UNAVAILABLE = "Error sending RTP: Network is unreachable";
+    private static final String NETWORK_UNAVAILABLE = "Error sending RTP: Network is unreachable";
 
     public static final String NETWORK_UNAVAILABLE_BROADCAST = "com.voipgrid.vialer.logging.sip.NETWORK_UNAVAILABLE_BROADCAST";
+
+    public static final String INVITE_FAILED_WITH_SIP_ERROR_CODE = "com.voipgrid.vialer.logging.sip.INVITE_FAILED_WITH_SIP_ERROR_CODE";
+
+    public static final String EXTRA_SIP_ERROR_CODE = "com.voipgrid.vialer.logging.sip.EXTRA_SIP_ERROR_CODE";
 
     /**
      * Perform various tasks based on pjsip logs.
@@ -19,11 +27,62 @@ public class SipLogHandler {
      * @param log
      */
     public void handle(String log) {
-        if(log == null) return;
+        if (log == null) return;
 
-        if(log.contains(NETWORK_UNAVAILABLE)) {
+        if (log.contains(NETWORK_UNAVAILABLE)) {
             performNetworkSwitch();
         }
+
+        if (isInvite(log)) {
+            Integer inviteFailedCode = extractFailedInviteCode(log);
+
+            if (inviteFailedCode != null) {
+                sendInviteFailedBroadcast(inviteFailedCode);
+            }
+        }
+    }
+
+    /**
+     * Send a broadcast to let listeners know that a failed invite was detected.
+     *
+     * @param inviteFailedCode
+     */
+    private void sendInviteFailedBroadcast(Integer inviteFailedCode) {
+        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(VialerApplication.get());
+        Intent intent = new Intent(SipLogHandler.INVITE_FAILED_WITH_SIP_ERROR_CODE);
+        intent.putExtra(EXTRA_SIP_ERROR_CODE, inviteFailedCode);
+        localBroadcastManager.sendBroadcast(intent);
+    }
+
+    /**
+     * Checks to see if the packet being inspected is an INVITE with a failed status code.
+     *
+     * @param log
+     * @return
+     */
+    private Integer extractFailedInviteCode(String log) {
+        ArrayList<String> matches = StringUtil.extractCaptureGroups(log, "([0-9]{3})\\/([A-Z]+)");
+
+        if (matches.isEmpty()) {
+            return null;
+        }
+
+        String code = matches.get(0);
+        String method = matches.get(1);
+
+        if (!method.equals("INVITE")) {
+            return null;
+        }
+
+        if (!code.startsWith("4") && !code.startsWith("5")) {
+            return null;
+        }
+
+        return Integer.valueOf(code);
+    }
+
+    private boolean isInvite(String log) {
+        return log.contains("INVITE");
     }
 
     /**

--- a/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
@@ -79,13 +79,13 @@ public class CallSetupChecker {
      */
     private boolean check() {
         if (isSipServiceHandlingOurCall()){
-            mRemoteLogger.i("Confirmed call with middleware key:" + mRequestToken);
+            mRemoteLogger.i("Confirmed call from fcm message (" + mRequestToken + ") has been setup");
             return false;
         }
 
         if (hasMaximumAllowedTimeExpired()) {
             VialerStatistics.noCallReceivedFromAsteriskAfterOkToMiddleware(mRequestToken, mMessageStartTime, mAttempt);
-            mRemoteLogger.e("failed to confirm call with middleware key:" + mRequestToken);
+            mRemoteLogger.e("Unable to confirm call from fcm message (" + mRequestToken + ") was setup correctly");
             return false;
         }
 

--- a/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
@@ -27,7 +27,7 @@ public class CallSetupChecker {
     private final String mAttempt;
     private long mCheckStartTime;
     private final RemoteLogger mRemoteLogger;
-    private WeakReference<SipService> mSipService;
+    private SipService mSipService;
 
     private CallSetupChecker (String requestToken, String messageStartTime, String attempt) {
         mRequestToken = requestToken;
@@ -53,7 +53,7 @@ public class CallSetupChecker {
      *
      */
     public void start(SipService sipService) {
-        mSipService = new WeakReference<>(sipService);
+        mSipService = sipService;
 
         mCheckStartTime = System.currentTimeMillis();
 
@@ -107,8 +107,8 @@ public class CallSetupChecker {
      * Check if the SipService is currently busy with the call we are checking for.
      */
     private boolean isSipServiceHandlingOurCall() {
-        return mSipService != null && mSipService.get().getCurrentCall() != null && mRequestToken.equals(
-                mSipService.get().getCurrentCall().getMiddlewareKey());
+        return mSipService != null && mSipService.getCurrentCall() != null && mRequestToken.equals(
+                mSipService.getCurrentCall().getMiddlewareKey());
     }
 
     /**

--- a/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/CallSetupChecker.java
@@ -1,0 +1,125 @@
+package com.voipgrid.vialer.sip;
+
+import com.voipgrid.vialer.logging.RemoteLogger;
+import com.voipgrid.vialer.statistics.VialerStatistics;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Regularly checks that a call has been setup after receiving a push notification.
+ */
+public class CallSetupChecker {
+
+    /**
+     * The number of seconds that we wait for a call before we determine that it has failed
+     * to setup.
+     */
+    private static final int MILLISECONDS_ALLOWED_BEFORE_CALL_FAILED_TO_SETUP = 5000;
+
+    /**
+     * The time between each check that is performed, this should be set to a low enough value
+     * that it will always catch a call that has been active for even a short amount of time.
+     */
+    private static final int CHECK_INTERVAL_IN_MILLISECONDS = 50;
+
+    private final String mRequestToken;
+    private final String mMessageStartTime;
+    private final String mAttempt;
+    private long mCheckStartTime;
+    private final RemoteLogger mRemoteLogger;
+    private WeakReference<SipService> mSipService;
+
+    private CallSetupChecker (String requestToken, String messageStartTime, String attempt) {
+        mRequestToken = requestToken;
+        mMessageStartTime = messageStartTime;
+        mAttempt = attempt;
+        mRemoteLogger = new RemoteLogger(this.getClass()).enableConsoleLogging();
+    }
+
+    /**
+     * Create a new callsetupchecker with the relevant information from the middleware push message.
+     *
+     * @param requestToken
+     * @param messageStartTime
+     * @param attempt
+     * @return
+     */
+    public static CallSetupChecker withPushMessageInformation(String requestToken, String messageStartTime, String attempt) {
+        return new CallSetupChecker(requestToken, messageStartTime, attempt);
+    }
+
+    /**
+     * Starts a new thread that will regularly check that the sip service is handling the call.
+     *
+     */
+    public void start(SipService sipService) {
+        mSipService = new WeakReference<>(sipService);
+
+        mCheckStartTime = System.currentTimeMillis();
+
+        new Thread(this::loop).start();
+    }
+
+    /**
+     * Calls the check method continuously.
+     *
+     */
+    private void loop() {
+        boolean continueChecking = true;
+
+        while (continueChecking) {
+            continueChecking = check();
+        }
+    }
+
+    /**
+     * Looks for whether or not the call is active in the SipService or if we have reached the maximum allowed time for checking.
+     *
+     * @return Return a boolean depending on whether or not we should continue checking for the call.
+     */
+    private boolean check() {
+        if (isSipServiceHandlingOurCall()){
+            mRemoteLogger.i("Confirmed call with middleware key:" + mRequestToken);
+            return false;
+        }
+
+        if (hasMaximumAllowedTimeExpired()) {
+            VialerStatistics.noCallReceivedFromAsteriskAfterOkToMiddleware(mRequestToken, mMessageStartTime, mAttempt);
+            mRemoteLogger.e("failed to confirm call with middleware key:" + mRequestToken);
+            return false;
+        }
+
+        sleep();
+
+        return true;
+    }
+
+    /**
+     * Determine if we have been checking for longer than the allowed time.
+     *
+     * @return
+     */
+    private boolean hasMaximumAllowedTimeExpired() {
+        return System.currentTimeMillis() >= (mCheckStartTime + MILLISECONDS_ALLOWED_BEFORE_CALL_FAILED_TO_SETUP);
+    }
+
+    /**
+     * Check if the SipService is currently busy with the call we are checking for.
+     */
+    private boolean isSipServiceHandlingOurCall() {
+        return mSipService != null && mSipService.get().getCurrentCall() != null && mRequestToken.equals(
+                mSipService.get().getCurrentCall().getMiddlewareKey());
+    }
+
+    /**
+     * Sleep the current thread for the specified check interval.
+     *
+     */
+    private void sleep() {
+        try {
+            Thread.sleep(CHECK_INTERVAL_IN_MILLISECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
@@ -28,6 +28,7 @@ import com.voipgrid.vialer.fcm.FcmMessagingService;
 import com.voipgrid.vialer.logging.LogHelper;
 import com.voipgrid.vialer.logging.RemoteLogger;
 import com.voipgrid.vialer.logging.sip.SipLogHandler;
+import com.voipgrid.vialer.statistics.VialerStatistics;
 import com.voipgrid.vialer.util.ConnectivityHelper;
 import com.voipgrid.vialer.util.UserAgent;
 
@@ -464,6 +465,7 @@ public class SipConfig implements AccountStatus {
         String url = incomingCallDetails.getStringExtra(SipConstants.EXTRA_RESPONSE_URL);
         String messageStartTime = incomingCallDetails.getStringExtra(FcmMessagingService.MESSAGE_START_TIME);
         String token = incomingCallDetails.getStringExtra(SipConstants.EXTRA_REQUEST_TOKEN);
+        String attempt = incomingCallDetails.getStringExtra(FcmMessagingService.ATTEMPT);
 
         // Set responded as soon as possible to avoid duplicate requests due to multiple
         // onAccountRegistered calls in a row.
@@ -511,6 +513,8 @@ public class SipConfig implements AccountStatus {
                 mSipService.stopSelf();
             }
         });
+
+        CallSetupChecker.withPushMessageInformation(token, messageStartTime, attempt).start(mSipService);
     }
 
     @Override

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
@@ -28,7 +28,6 @@ import com.voipgrid.vialer.fcm.FcmMessagingService;
 import com.voipgrid.vialer.logging.LogHelper;
 import com.voipgrid.vialer.logging.RemoteLogger;
 import com.voipgrid.vialer.logging.sip.SipLogHandler;
-import com.voipgrid.vialer.statistics.VialerStatistics;
 import com.voipgrid.vialer.util.ConnectivityHelper;
 import com.voipgrid.vialer.util.UserAgent;
 

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -31,7 +31,6 @@ import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_CALL_DIRECTION
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_CALL_SETUP_FAILED;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_CALL_SETUP_SUCCESSFUL;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_GSM_CALL_IN_PROGRESS;
-import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_VIALER_CALL_IN_PROGRESS;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_INSUFFICIENT_NETWORK;
 import static com.voipgrid.vialer.statistics.StatsConstants
         .VALUE_FAILED_NO_CALL_RECEIVED_FROM_ASTERISK;
@@ -42,6 +41,7 @@ import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_REASON_
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_REASON_NO_AUDIO_SENT;
 import static com.voipgrid.vialer.statistics.StatsConstants
         .VALUE_FAILED_REASON_ORIGINATOR_CANCELLED;
+import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_FAILED_VIALER_CALL_IN_PROGRESS;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_HANGUP_REASON_REMOTE;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_HANGUP_REASON_USER;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_NETWORK_WIFI;
@@ -114,11 +114,11 @@ public class VialerStatistics {
                 .send();
     }
 
-    private static void incomingCallFailedDueToSipError(SipCall sipCall, int sipErrorCode) {
+    public static void incomingCallFailedDueToSipError(String requestToken, String messageStartTime, String attempt, int sipErrorCode) {
         VialerStatistics
                 .get()
                 .withDefaults()
-                .withCallInformation(sipCall)
+                .withMiddlewareInformation(requestToken, messageStartTime, attempt)
                 .withBluetoothInformation()
                 .addValue(KEY_FAILED_REASON, String.valueOf(sipErrorCode))
                 .send();

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -263,7 +263,7 @@ public class VialerStatistics {
 
     private VialerStatistics withMiddlewareInformation(String requestToken, String messageStartTime, String attempt) {
         addValue(KEY_MIDDLEWARE_KEY, requestToken);
-        addValue(KEY_TIME_TO_INITIAL_RESPONSE, String.valueOf(calculateTimeToInitialResponse(Double.valueOf(messageStartTime))));
+        addValue(KEY_TIME_TO_INITIAL_RESPONSE, String.valueOf(calculateTimeToInitialResponse(messageStartTime)));
         addValue(KEY_MIDDLEWARE_ATTEMPTS,attempt);
 
         return this;

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -146,11 +146,11 @@ public class VialerStatistics {
                 .send();
     }
 
-    public static void noCallReceivedFromAsteriskAfterOkToMiddleware(RemoteMessage middlewarePayload) {
+    public static void noCallReceivedFromAsteriskAfterOkToMiddleware(String requestToken, String messageStartTime, String attempt) {
         VialerStatistics
                 .get()
                 .withDefaults()
-                .withMiddlewareInformation(middlewarePayload)
+                .withMiddlewareInformation(requestToken, messageStartTime, attempt)
                 .addValue(KEY_FAILED_REASON, VALUE_FAILED_NO_CALL_RECEIVED_FROM_ASTERISK)
                 .send();
     }
@@ -256,9 +256,15 @@ public class VialerStatistics {
 
     private VialerStatistics withMiddlewareInformation(RemoteMessage middlewarePayload) {
         Map<String, String> data = middlewarePayload.getData();
-        addValue(KEY_MIDDLEWARE_KEY, data.get(REQUEST_TOKEN));
-        addValue(KEY_TIME_TO_INITIAL_RESPONSE, String.valueOf(calculateTimeToInitialResponse(data.get(MESSAGE_START_TIME))));
-        addValue(KEY_MIDDLEWARE_ATTEMPTS, data.get(ATTEMPT));
+        withMiddlewareInformation(data.get(REQUEST_TOKEN), data.get(MESSAGE_START_TIME), data.get(ATTEMPT));
+
+        return this;
+    }
+
+    private VialerStatistics withMiddlewareInformation(String requestToken, String messageStartTime, String attempt) {
+        addValue(KEY_MIDDLEWARE_KEY, requestToken);
+        addValue(KEY_TIME_TO_INITIAL_RESPONSE, String.valueOf(calculateTimeToInitialResponse(Double.valueOf(messageStartTime))));
+        addValue(KEY_MIDDLEWARE_ATTEMPTS,attempt);
 
         return this;
     }
@@ -271,6 +277,7 @@ public class VialerStatistics {
         addValue(KEY_NETWORK, mDefaultDataProvider.getNetwork());
         if (!mDefaultDataProvider.getNetwork().equals(VALUE_NETWORK_WIFI)) {
             addValue(KEY_NETWORK_OPERATOR, mDefaultDataProvider.getNetworkOperator());
+        }
         addValue(KEY_DEVICE_MANUFACTURER, mDefaultDataProvider.getDeviceManufacturer().toLowerCase());
         addValue(KEY_DEVICE_MODEL, mDefaultDataProvider.getDeviceModel().toLowerCase());
         addValue(KEY_CLIENT_COUNTRY, mDefaultDataProvider.getClientCountry());

--- a/app/src/main/java/com/voipgrid/vialer/util/StringUtil.java
+++ b/app/src/main/java/com/voipgrid/vialer/util/StringUtil.java
@@ -2,6 +2,7 @@ package com.voipgrid.vialer.util;
 
 import android.support.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,15 +16,38 @@ public class StringUtil {
      * @return The captured group or null if not found
      */
     public static @Nullable String extractFirstCaptureGroupFromString(String subject, String pattern) {
+        return extractCaptureGroups(subject, pattern).get(0);
+    }
+
+    public static ArrayList<String> extractCaptureGroups(String subject, String pattern) {
+
         if (subject == null) return null;
 
         Pattern p = Pattern.compile(pattern);
         Matcher m = p.matcher(subject);
 
         if (!m.find()) {
-            return null;
+            return new ArrayList<>();
         }
 
-        return m.group(1);
+        ArrayList<String> matches = new ArrayList<>();
+
+        int i = 1;
+
+        while(true) {
+            try {
+                String match = m.group(i);
+
+                if (match == null) {
+                    return matches;
+                }
+
+                matches.add(match);
+
+                i++;
+            } catch (Exception e) {
+                return matches;
+            }
+        }
     }
 }


### PR DESCRIPTION
Combined two tickets and code was written with Stella.

When an ok is posted to the middleware a new thread will monitor the call for the next 5 seconds, it will:

- Do nothing if the call is setup successfully (in the sipservice)
- Report sip code error if a 4xx/5xx is in a sip invite packet
- Report OK_MIDDLEWARE_NO_CALL if nothing was setup within 5 seconds