### PR TITLE
Ignoring 407 status codes as these appear as part of standard messagi…

### DIFF
--- a/app/src/main/java/com/voipgrid/vialer/logging/sip/SipLogHandler.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/sip/SipLogHandler.java
@@ -7,6 +7,7 @@ import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.util.StringUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Performs various actions based on the result of the pjsip logs.
@@ -20,6 +21,13 @@ public class SipLogHandler {
     public static final String INVITE_FAILED_WITH_SIP_ERROR_CODE = "com.voipgrid.vialer.logging.sip.INVITE_FAILED_WITH_SIP_ERROR_CODE";
 
     public static final String EXTRA_SIP_ERROR_CODE = "com.voipgrid.vialer.logging.sip.EXTRA_SIP_ERROR_CODE";
+
+    /**
+     * Any status codes in this list will not count as failure status codes even if they are 4xx or 5xx as
+     * they are standard messages.
+     *
+     */
+    private static final int[] IGNORED_STATUS_CODES = { 407 };
 
     /**
      * Perform various tasks based on pjsip logs.
@@ -36,7 +44,7 @@ public class SipLogHandler {
         if (isInvite(log)) {
             Integer inviteFailedCode = extractFailedInviteCode(log);
 
-            if (inviteFailedCode != null) {
+            if (inviteFailedCode != null && !Arrays.asList(IGNORED_STATUS_CODES).contains(inviteFailedCode)) {
                 sendInviteFailedBroadcast(inviteFailedCode);
             }
         }

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
@@ -162,12 +162,23 @@ public class SipCall extends org.pjsip.pjsua2.Call {
         TimeVal timeVal = new TimeVal();
         try {
             CallInfo callInfo = this.getInfo();
-            timeVal = callInfo.getConnectDuration();
+            return callInfo.getConnectDuration().getSec();
         } catch (Exception e) {
-            e.printStackTrace();
+            return timeVal.getSec();
         }
+    }
 
-        return timeVal.getSec();
+    /**
+     * Get the call duration in milliseconds, this will use the stored callinfo
+     * so should not be used for live duration reporting but only for getting the
+     * duration at the end of the call.
+     *
+     * @return
+     */
+    public int getCallDurationInMilliseconds() {
+        TimeVal timeVal = mLastCallInfo.getConnectDuration();
+
+        return (timeVal.getSec() * 1000) + timeVal.getMsec();
     }
 
     private String getCodec() {

--- a/app/src/main/java/com/voipgrid/vialer/statistics/StatsConstants.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/StatsConstants.java
@@ -24,7 +24,7 @@ public interface StatsConstants {
     String KEY_SIP_USER_ID = "sip_user_id";
     String KEY_CONNECTION_TYPE = "connection_type";
     String KEY_ACCOUNT_CONNECTION_TYPE = "account_connection_type";
-
+    String KEY_CALL_DURATION = "call_duration";
 
     String VALUE_OS = "Android";
     String VALUE_APP_STATUS_ALPHA = "Alpha";

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -10,6 +10,7 @@ import static com.voipgrid.vialer.statistics.StatsConstants.KEY_APP_VERSION;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_BLUETOOTH_AUDIO_ENABLED;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_BLUETOOTH_DEVICE_NAME;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_CALL_DIRECTION;
+import static com.voipgrid.vialer.statistics.StatsConstants.KEY_CALL_DURATION;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_CALL_ID;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_CALL_SETUP_SUCCESSFUL;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_CLIENT_COUNTRY;
@@ -51,6 +52,7 @@ import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_NETWORK_WIFI;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_OS;
 
 import android.content.Context;
+import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
 import com.google.gson.GsonBuilder;
@@ -245,6 +247,7 @@ public class VialerStatistics {
                 .withCallInformation(sipCall)
                 .withBluetoothInformation()
                 .addValue(KEY_HANGUP_REASON, VALUE_HANGUP_REASON_USER)
+                .addValue(KEY_CALL_DURATION, String.valueOf(sipCall.getCallDurationInMilliseconds()))
                 .send();
     }
 
@@ -255,6 +258,7 @@ public class VialerStatistics {
                 .withCallInformation(sipCall)
                 .withBluetoothInformation()
                 .addValue(KEY_HANGUP_REASON, VALUE_HANGUP_REASON_REMOTE)
+                .addValue(KEY_CALL_DURATION, String.valueOf(sipCall.getCallDurationInMilliseconds()))
                 .send();
     }
 
@@ -295,7 +299,10 @@ public class VialerStatistics {
     }
 
     private VialerStatistics withCallInformation(SipCall call) {
-        addValue(KEY_MIDDLEWARE_KEY, call.getMiddlewareKey());
+        if (call.getMiddlewareKey() != null && !call.getMiddlewareKey().isEmpty()) {
+            addValue(KEY_MIDDLEWARE_KEY, call.getMiddlewareKey());
+        }
+
         addValue(KEY_CALL_ID, call.getAsteriskCallId());
         addValue(KEY_CALL_DIRECTION, call.getCallDirection());
         addValue(KEY_CONNECTION_TYPE, call.getTransport() != null ? call.getTransport().toUpperCase() : "");


### PR DESCRIPTION
…ng, correctly getting the call duration for completed calls and no longer sending middleware key if one does not exist.