### PR TITLE
VIALA-867/889: Improved fcm message handling

### DIFF
--- a/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
@@ -5,9 +5,11 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
 import android.support.annotation.NonNull;
+import android.support.v4.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
@@ -20,6 +22,7 @@ import com.voipgrid.vialer.sip.SipService;
 import com.voipgrid.vialer.sip.SipUri;
 import com.voipgrid.vialer.statistics.VialerStatistics;
 import com.voipgrid.vialer.util.ConnectivityHelper;
+import com.voipgrid.vialer.util.NotificationHelper;
 import com.voipgrid.vialer.util.PhoneNumberUtils;
 
 import okhttp3.ResponseBody;
@@ -45,6 +48,8 @@ public class FcmMessagingService extends FirebaseMessagingService {
      * for.
      */
     private static String sLastHandledCall;
+
+    public static final String VOIP_HAS_BEEN_DISABLED = "com.voipgrid.vialer.voip_disabled";
 
     private RemoteLogger mRemoteLogger;
     private AnalyticsHelper mAnalyticsHelper;
@@ -124,7 +129,13 @@ public class FcmMessagingService extends FirebaseMessagingService {
      * @param remoteMessageData
      */
     private void handleMessage(RemoteMessage remoteMessage, RemoteMessageData remoteMessageData) {
-        mRemoteLogger.d("Code not implemented");
+        if (!remoteMessageData.isRegisteredOnOtherDeviceMessage()) {
+            return;
+        }
+
+        new Preferences(this).setSipEnabled(false);
+        NotificationHelper.getInstance(this).displayVoipDisabledNotification();
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(VOIP_HAS_BEEN_DISABLED));
     }
 
     /**

--- a/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
@@ -133,8 +133,13 @@ public class FcmMessagingService extends FirebaseMessagingService {
             return;
         }
 
+        Preferences preferences = new Preferences(this);
+
+        if (preferences.hasSipEnabled()) {
+            NotificationHelper.getInstance(this).displayVoipDisabledNotification();
+        }
+
         new Preferences(this).setSipEnabled(false);
-        NotificationHelper.getInstance(this).displayVoipDisabledNotification();
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(VOIP_HAS_BEEN_DISABLED));
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
@@ -78,4 +78,13 @@ public class RemoteMessageData {
     public boolean isNumberSuppressed() {
         return mData.get(PHONE_NUMBER) != null && (getPhoneNumber().equalsIgnoreCase(SUPPRESSED) || getPhoneNumber().toLowerCase().contains("xxxx"));
     }
+
+    /**
+     * Is a message that is letting us know that the device has been registered on another device.
+     *
+     * @return
+     */
+    public boolean isRegisteredOnOtherDeviceMessage() {
+        return isMessageRequest() && !mData.get(MESSAGE_REQUEST_TYPE).isEmpty();
+    }
 }

--- a/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
@@ -6,16 +6,16 @@ public class RemoteMessageData {
 
     private final static String MESSAGE_TYPE = "type";
 
-    private final static String CALL_REQUEST_TYPE = "call";
-    private final static String MESSAGE_REQUEST_TYPE = "message";
+    public final static String CALL_REQUEST_TYPE = "call";
+    public final static String MESSAGE_REQUEST_TYPE = "message";
 
-    private final static String RESPONSE_URL = "response_api";
-    private final static String REQUEST_TOKEN = "unique_key";
-    private final static String PHONE_NUMBER = "phonenumber";
-    private final static String CALLER_ID = "caller_id";
-    private static final String SUPPRESSED = "supressed";
-    private static final String ATTEMPT = "attempt";
-    static final String MESSAGE_START_TIME = "message_start_time";
+    public final static String RESPONSE_URL = "response_api";
+    public final static String REQUEST_TOKEN = "unique_key";
+    public final static String PHONE_NUMBER = "phonenumber";
+    public final static String CALLER_ID = "caller_id";
+    public static final String SUPPRESSED = "supressed";
+    public static final String ATTEMPT = "attempt";
+    public static final String MESSAGE_START_TIME = "message_start_time";
 
     private Map<String, String> mData;
 

--- a/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/RemoteMessageData.java
@@ -1,0 +1,81 @@
+package com.voipgrid.vialer.fcm;
+
+import java.util.Map;
+
+public class RemoteMessageData {
+
+    private final static String MESSAGE_TYPE = "type";
+
+    private final static String CALL_REQUEST_TYPE = "call";
+    private final static String MESSAGE_REQUEST_TYPE = "message";
+
+    private final static String RESPONSE_URL = "response_api";
+    private final static String REQUEST_TOKEN = "unique_key";
+    private final static String PHONE_NUMBER = "phonenumber";
+    private final static String CALLER_ID = "caller_id";
+    private static final String SUPPRESSED = "supressed";
+    private static final String ATTEMPT = "attempt";
+    static final String MESSAGE_START_TIME = "message_start_time";
+
+    private Map<String, String> mData;
+
+    public RemoteMessageData(Map<String, String> data) {
+        mData = data;
+    }
+
+    public String getRequestType() {
+        return this.mData.get(MESSAGE_TYPE);
+    }
+
+    public boolean hasRequestType() {
+        return getRequestType() != null;
+    }
+
+    public boolean isCallRequest() {
+        return getRequestType().equals(CALL_REQUEST_TYPE);
+    }
+
+    public boolean isMessageRequest() {
+        return getRequestType().equals(MESSAGE_REQUEST_TYPE);
+    }
+
+    public String getCallerId() {
+        return propertyOrEmptyString(CALLER_ID);
+    }
+
+    public String getResponseUrl() {
+        return propertyOrEmptyString(RESPONSE_URL);
+    }
+
+    public String getRequestToken() {
+        return propertyOrEmptyString(REQUEST_TOKEN);
+    }
+
+    public String getMessageStartTime() {
+        return propertyOrEmptyString(MESSAGE_START_TIME);
+    }
+
+    public String getPhoneNumber() {
+        return propertyOrEmptyString(PHONE_NUMBER);
+    }
+
+    public String getSupressed() {
+        return propertyOrEmptyString(SUPPRESSED);
+    }
+
+    public int getAttemptNumber() {
+        return Integer.parseInt(propertyOrEmptyString(ATTEMPT));
+    }
+
+    public Map<String, String> getRawData() {
+        return mData;
+    }
+
+    private String propertyOrEmptyString(String property) {
+        return mData.get(property) != null ? mData.get(property) : "";
+    }
+
+    public boolean isNumberSuppressed() {
+        return mData.get(PHONE_NUMBER) != null && (getPhoneNumber().equalsIgnoreCase(SUPPRESSED) || getPhoneNumber().toLowerCase().contains("xxxx"));
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/logging/LogHelper.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/LogHelper.java
@@ -1,6 +1,7 @@
 package com.voipgrid.vialer.logging;
 
-import static com.voipgrid.vialer.fcm.FcmMessagingService.CALL_REQUEST_TYPE;
+
+import static com.voipgrid.vialer.fcm.RemoteMessageData.CALL_REQUEST_TYPE;
 
 import com.google.firebase.messaging.RemoteMessage;
 import com.google.gson.Gson;

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipAccount.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipAccount.java
@@ -1,5 +1,7 @@
 package com.voipgrid.vialer.sip;
 
+import static com.voipgrid.vialer.fcm.RemoteMessageData.MESSAGE_START_TIME;
+
 import android.content.Intent;
 
 import com.voipgrid.vialer.fcm.FcmMessagingService;
@@ -46,7 +48,7 @@ class SipAccount extends org.pjsip.pjsua2.Account {
         if (mSipService != null && mSipService.getIncomingCallDetails() != null) {
             Intent incomingCallDetails = mSipService.getIncomingCallDetails();
             sipCall.setMiddlewareKey(incomingCallDetails.getStringExtra(SipConstants.EXTRA_REQUEST_TOKEN));
-            sipCall.setMessageStartTime(incomingCallDetails.getStringExtra(FcmMessagingService.MESSAGE_START_TIME));
+            sipCall.setMessageStartTime(incomingCallDetails.getStringExtra(MESSAGE_START_TIME));
         }
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
@@ -25,6 +25,7 @@ import com.voipgrid.vialer.api.SecureCalling;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.fcm.FcmMessagingService;
+import com.voipgrid.vialer.fcm.RemoteMessageData;
 import com.voipgrid.vialer.logging.LogHelper;
 import com.voipgrid.vialer.logging.RemoteLogger;
 import com.voipgrid.vialer.logging.sip.SipLogHandler;
@@ -462,9 +463,9 @@ public class SipConfig implements AccountStatus {
         }
 
         String url = incomingCallDetails.getStringExtra(SipConstants.EXTRA_RESPONSE_URL);
-        String messageStartTime = incomingCallDetails.getStringExtra(FcmMessagingService.MESSAGE_START_TIME);
+        String messageStartTime = incomingCallDetails.getStringExtra(RemoteMessageData.MESSAGE_START_TIME);
         String token = incomingCallDetails.getStringExtra(SipConstants.EXTRA_REQUEST_TOKEN);
-        String attempt = incomingCallDetails.getStringExtra(FcmMessagingService.ATTEMPT);
+        String attempt = incomingCallDetails.getStringExtra(RemoteMessageData.ATTEMPT);
 
         // Set responded as soon as possible to avoid duplicate requests due to multiple
         // onAccountRegistered calls in a row.

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
@@ -66,7 +66,7 @@ public class SipConfig implements AccountStatus {
 
     private static final String TAG = SipConfig.class.getSimpleName();
 
-    private Endpoint mEndpoint;
+    private VialerEndpoint mEndpoint;
     private PhoneAccount mPhoneAccount;
     private RemoteLogger mRemoteLogger;
     private SipAccount mSipAccount;
@@ -97,7 +97,7 @@ public class SipConfig implements AccountStatus {
         mPreferences = new Preferences(VialerApplication.get());
     }
 
-    public Endpoint getEndpoint() {
+    public VialerEndpoint getEndpoint() {
         return mEndpoint;
     }
 
@@ -272,9 +272,9 @@ public class SipConfig implements AccountStatus {
      * @return
      * @throws LibraryInitFailedException
      */
-    private Endpoint createEndpoint() throws LibraryInitFailedException {
+    private VialerEndpoint createEndpoint() throws LibraryInitFailedException {
         mRemoteLogger.d("createEndpoint");
-        Endpoint endpoint = new Endpoint();
+        VialerEndpoint endpoint = new VialerEndpoint();
         EpConfig endpointConfig = new EpConfig();
 
         // Set echo cancellation options for endpoint.

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipService.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipService.java
@@ -174,6 +174,7 @@ public class SipService extends Service {
             mSipConfig = new SipConfig(this, phoneAccount);
             try {
                 mSipConfig.initLibrary();
+                mSipConfig.getEndpoint().setSipService(this);
             } catch (SipConfig.LibraryInitFailedException e) {
                 stopSelf();
             }

--- a/app/src/main/java/com/voipgrid/vialer/sip/VialerEndpoint.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/VialerEndpoint.java
@@ -1,0 +1,49 @@
+package com.voipgrid.vialer.sip;
+
+import com.voipgrid.vialer.logging.RemoteLogger;
+
+import org.pjsip.pjsua2.CallOpParam;
+import org.pjsip.pjsua2.Endpoint;
+import org.pjsip.pjsua2.OnTransportStateParam;
+import org.pjsip.pjsua2.pjsip_transport_state;
+
+public class VialerEndpoint extends Endpoint {
+
+    private final RemoteLogger mLogger;
+    private SipService mSipService;
+
+    VialerEndpoint() {
+        super();
+        mLogger = new RemoteLogger(this.getClass());
+    }
+
+    @Override
+    public void onTransportState(OnTransportStateParam prm) {
+        super.onTransportState(prm);
+
+        if (!prm.getState().equals(pjsip_transport_state.PJSIP_TP_STATE_CONNECTED)) {
+            return;
+        }
+
+        if (mSipService == null || mSipService.getCurrentCall() == null) {
+            return;
+        }
+
+        SipCall sipCall = mSipService.getCurrentCall();
+
+        if (sipCall.isIpChangeInProgress()) {
+            return;
+        }
+
+        try {
+            sipCall.reinvite(new CallOpParam(true));
+            mLogger.i("There has been a new transport created. Reinivite the calls to keep the call going.");
+        } catch (Exception e) {
+            mLogger.e("Unable to reinvite call");
+        }
+    }
+
+    public void setSipService(SipService sipService) {
+        mSipService = sipService;
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -1,9 +1,9 @@
 package com.voipgrid.vialer.statistics;
 
 
-import static com.voipgrid.vialer.fcm.FcmMessagingService.ATTEMPT;
-import static com.voipgrid.vialer.fcm.FcmMessagingService.MESSAGE_START_TIME;
-import static com.voipgrid.vialer.fcm.FcmMessagingService.REQUEST_TOKEN;
+import static com.voipgrid.vialer.fcm.RemoteMessageData.ATTEMPT;
+import static com.voipgrid.vialer.fcm.RemoteMessageData.MESSAGE_START_TIME;
+import static com.voipgrid.vialer.fcm.RemoteMessageData.REQUEST_TOKEN;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_ACCOUNT_CONNECTION_TYPE;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_APP_STATUS;
 import static com.voipgrid.vialer.statistics.StatsConstants.KEY_APP_VERSION;

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -224,6 +224,7 @@
     <string name="advanced_settings_stun_description">STUN kan de connectie met het netwerk verbeteren als je NAT problemen hebt.
     </string>
     <string name="call_not_encrypted_warning_bar_text">Gesprek niet versleuteld</string>
+    <string name="notification_channel_voip_disabled">Je VoIP account is geregistreerd op een ander apparaat. Je kunt VoIP weer activeren bij instellingen</string>
 
     <string name="t9helper_title">Tip</string>
     <string name="t9helper_text">Je kunt zoeken op %1$s door de volgende nummers op het toetsenbord in te drukken.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,4 +231,5 @@
     <string name="t9helper_text">You can search for %1$s by keying the numbers on the dialpad below.</string>
     <string name="t9helper_joining_character" translatable="false">+</string>
     <string name="call_not_encrypted_warning_bar_text">Call not encrypted</string>
+    <string name="notification_channel_voip_disabled">Your VoIP account has been registered on another device. You can re-enable VoIP in Settings</string>
 </resources>


### PR DESCRIPTION
Refactored the FcmMessagingService to make it clearer and so we are no longer responding as lacking connection when there is actually a call in progress.

Disabling VoIP switch and displaying a high priority notification when the middleware says another device has registered for this voip account