### PR TITLE
VIALA-726: Add buffer for remote logs

### DIFF
--- a/app/src/main/java/com/voipgrid/vialer/logging/Buffer.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/Buffer.java
@@ -1,0 +1,60 @@
+package com.voipgrid.vialer.logging;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Buffer {
+
+    /**
+     * The default size of the buffer, if no buffer size is declared then this will be used.
+     *
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 100;
+
+    /**
+     * The size of the buffer, this amount of records will be stored in the buffer before old
+     * records are removed from the stack.
+     *
+     */
+    private int mSize;
+
+    private List<String> buffer = new ArrayList<>();
+
+    Buffer(int size) {
+        mSize = size;
+    }
+
+    Buffer() {
+        mSize = DEFAULT_BUFFER_SIZE;
+    }
+
+    /**
+     * Get the contents of the buffer.
+     *
+     * @return A List of strings that have been added to the buffer.
+     */
+    public List<String> get() {
+        return buffer;
+    }
+
+    /**
+     * Add a new string to the buffer.
+     *
+     * @param log The string that will be added to the buffer
+     */
+    public void add(String log) {
+        if (buffer.size() >= mSize) {
+            buffer.remove(0);
+        }
+
+        buffer.add(log);
+    }
+
+    /**
+     * Remove all logs from the buffer.
+     *
+     */
+    public void clear() {
+        buffer = new ArrayList<>();
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/logging/Logger.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/Logger.java
@@ -13,6 +13,7 @@ import com.voipgrid.vialer.logging.tracing.CallerLocator;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.List;
 
 /**
  * Class used for sending logs to a remote service.
@@ -39,8 +40,14 @@ public class Logger {
     private CallerLocator mCallerLocator;
     private LogFileCreator mLogFileCreator;
 
+    private static Buffer sBuffer;
+
     private boolean mRemoteLoggingEnabled;
     private boolean mLogToConsole = true;
+
+    static  {
+        sBuffer = new Buffer();
+    }
 
     public Logger(Class thisClass) {
         mContext = VialerApplication.get();
@@ -115,9 +122,7 @@ public class Logger {
             logToConsole(level, tag, message);
         }
 
-        if (mRemoteLoggingEnabled) {
-            logToRemote(level, tag, message);
-        }
+        logToRemote(level, tag, message);
     }
 
     /**
@@ -156,7 +161,11 @@ public class Logger {
             message = mLogFormatter.applyAllFormatters(tag, message);
             message = mLogComposer.compose(level, tag, message);
 
-            logEntryLogger.log(message);
+            if (mRemoteLoggingEnabled) {
+                logEntryLogger.log(message);
+            } else {
+                sBuffer.add(message);
+            }
         } catch (Exception e) {
             // Avoid crashing the app in background logging.
         }
@@ -207,4 +216,20 @@ public class Logger {
         log(EXCEPTION_TAG, message);
     }
 
+    /**
+     * Sends the entire contents of the buffer to remote.
+     *
+     */
+    void logBufferToRemote() {
+        List<String> buffer = sBuffer.get();
+        sBuffer.clear();
+
+        if (logEntryLogger == null) {
+            return;
+        }
+
+        for (String log : buffer) {
+            logEntryLogger.log(log + " (FROM LOG BUFFER)");
+        }
+    }
 }

--- a/app/src/main/java/com/voipgrid/vialer/logging/RemoteUncaughtExceptionHandler.java
+++ b/app/src/main/java/com/voipgrid/vialer/logging/RemoteUncaughtExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.voipgrid.vialer.logging;
 
-import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
@@ -12,11 +11,9 @@ import com.voipgrid.vialer.BuildConfig;
  */
 public class RemoteUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
 
-    private Context mContext;
     private Thread.UncaughtExceptionHandler mDefaultHandler;
 
-    public RemoteUncaughtExceptionHandler(Context context) {
-        mContext = context;
+    RemoteUncaughtExceptionHandler() {
         mDefaultHandler = Thread.getDefaultUncaughtExceptionHandler();
     }
 
@@ -28,6 +25,7 @@ public class RemoteUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
     private void logStackTrace(Throwable exception) {
         Logger logger = new Logger(RemoteUncaughtExceptionHandler.class).forceRemoteLogging(true);
+        logger.logBufferToRemote();
         String stackTrace = Log.getStackTraceString(exception);
         String traceID = LogUuidGenerator.generate();
 

--- a/app/src/test/java/com/voipgrid/vialer/PhoneNumberUtilsTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/PhoneNumberUtilsTest.java
@@ -1,4 +1,4 @@
-package com.voipgrid.vialer.test;
+package com.voipgrid.vialer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/app/src/test/java/com/voipgrid/vialer/logging/BufferTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/logging/BufferTest.java
@@ -1,0 +1,63 @@
+package com.voipgrid.vialer.logging;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BufferTest {
+
+    @Test
+    public void it_only_stores_up_to_the_defined_buffer_size() {
+        Buffer buffer = new Buffer(10);
+        addStringsToBuffer(buffer, 10);
+        assertEquals(10, buffer.get().size());
+
+        buffer = new Buffer(10);
+        addStringsToBuffer(buffer, 5);
+        assertEquals(5, buffer.get().size());
+
+        buffer = new Buffer(10);
+        addStringsToBuffer(buffer, 20);
+        assertEquals(10, buffer.get().size());
+    }
+
+    @Test
+    public void it_returns_the_buffer_in_the_order_they_were_inserted() {
+        String firstLog = "first log", secondLog = "second log", thirdLog = "third log";
+
+        Buffer buffer = new Buffer(5);
+        buffer.add(firstLog);
+        buffer.add(secondLog);
+        buffer.add(thirdLog);
+
+        assertEquals(firstLog, buffer.get().get(0));
+    }
+
+    @Test
+    public void it_removes_excess_logs_starting_with_the_oldest() {
+        String firstLog = "first log", secondLog = "second log", thirdLog = "third log";
+
+        Buffer buffer = new Buffer(2);
+        buffer.add(firstLog);
+        buffer.add(secondLog);
+        buffer.add(thirdLog);
+
+        assertEquals(secondLog, buffer.get().get(0));
+    }
+
+    @Test
+    public void it_is_possible_to_clear_the_buffer() {
+        Buffer buffer = new Buffer();
+        buffer.add("first log");
+        buffer.add("second log");
+        assertEquals(2, buffer.get().size());
+        buffer.clear();
+        assertEquals(0, buffer.get().size());
+    }
+
+    private void addStringsToBuffer(Buffer buffer, int amount) {
+        for (int i = 0; i < amount; i++) {
+            buffer.add("A test string");
+        }
+    }
+}

--- a/app/src/test/java/com/voipgrid/vialer/logging/LogComposerTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/logging/LogComposerTest.java
@@ -1,10 +1,7 @@
-package com.voipgrid.vialer.test.logging;
+package com.voipgrid.vialer.logging;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-
-import com.voipgrid.vialer.logging.DeviceInformation;
-import com.voipgrid.vialer.logging.LogComposer;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/app/src/test/java/com/voipgrid/vialer/logging/VialerLoggerTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/logging/VialerLoggerTest.java
@@ -1,4 +1,4 @@
-package com.voipgrid.vialer.test.logging;
+package com.voipgrid.vialer.logging;
 
 import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.when;
 import android.content.Context;
 
 import com.logentries.logger.AsyncLoggingWorker;
-import com.voipgrid.vialer.logging.LogEntriesFactory;
-import com.voipgrid.vialer.logging.VialerLogger;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/app/src/test/java/com/voipgrid/vialer/logging/formatting/PayloadAnonymizerTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/logging/formatting/PayloadAnonymizerTest.java
@@ -1,4 +1,4 @@
-package com.voipgrid.vialer.test.logging.formatting;
+package com.voipgrid.vialer.logging.formatting;
 
 import static org.junit.Assert.assertFalse;
 

--- a/app/src/test/java/com/voipgrid/vialer/logging/formatting/SipLogAnonymizerTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/logging/formatting/SipLogAnonymizerTest.java
@@ -1,4 +1,4 @@
-package com.voipgrid.vialer.test.logging.formatting;
+package com.voipgrid.vialer.logging.formatting;
 
 import static org.junit.Assert.assertFalse;
 

--- a/app/src/test/java/com/voipgrid/vialer/t9/T9NameMatcherTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/t9/T9NameMatcherTest.java
@@ -1,10 +1,8 @@
-package com.voipgrid.vialer.test.t9;
+package com.voipgrid.vialer.t9;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import com.voipgrid.vialer.t9.T9NameMatcher;
 
 import org.junit.Test;
 

--- a/app/src/test/java/com/voipgrid/vialer/t9/T9QueryTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/t9/T9QueryTest.java
@@ -1,8 +1,6 @@
-package com.voipgrid.vialer.test.t9;
+package com.voipgrid.vialer.t9;
 
 import static org.junit.Assert.assertEquals;
-
-import com.voipgrid.vialer.t9.T9Query;
 
 import org.junit.Test;
 

--- a/app/src/test/java/com/voipgrid/vialer/util/HtmlHelperTest.java
+++ b/app/src/test/java/com/voipgrid/vialer/util/HtmlHelperTest.java
@@ -1,8 +1,6 @@
-package com.voipgrid.vialer.test.util;
+package com.voipgrid.vialer.util;
 
 import static org.junit.Assert.*;
-
-import com.voipgrid.vialer.util.HtmlHelper;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Moved all tests to the main package (different root) so classes don't need to be public.

Added a buffer that will send remote logs to the server upon exception so we have more context when something goes wrong.