### PR TITLE
VIALA-341, VIALA-967, VIALA-966: Call records overhaul

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,6 +210,7 @@ dependencies {
     implementation 'com.yakivmospan:scytale:1.0.1'
     implementation "com.github.nisrulz:easydeviceinfo-base:2.4.1"
     implementation 'joda-time:joda-time:2.10.1'
+    implementation "android.arch.paging:runtime:1.0.1"
 
     // Testing below are supported api level because SNAPSHOT version is to unstable.
     testImplementation "org.robolectric:robolectric:${roboElectricVersion}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,8 +208,8 @@ dependencies {
 
     // Scytale -  Manage key generation
     implementation 'com.yakivmospan:scytale:1.0.1'
-
     implementation "com.github.nisrulz:easydeviceinfo-base:2.4.1"
+    implementation 'joda-time:joda-time:2.10.1'
 
     // Testing below are supported api level because SNAPSHOT version is to unstable.
     testImplementation "org.robolectric:robolectric:${roboElectricVersion}"

--- a/app/src/main/java/com/voipgrid/vialer/MainActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/MainActivity.java
@@ -38,9 +38,7 @@ import com.voipgrid.vialer.util.UpdateActivity;
 import com.voipgrid.vialer.util.UpdateHelper;
 
 
-public class MainActivity extends NavigationDrawerActivity implements
-        View.OnClickListener,
-        CallRecordFragment.OnFragmentInteractionListener {
+public class MainActivity extends NavigationDrawerActivity implements View.OnClickListener {
 
     private ViewPager mViewPager;
     private View mView;
@@ -294,11 +292,6 @@ public class MainActivity extends NavigationDrawerActivity implements
         } else {
             startActivity(intent);
         }
-    }
-
-    @Override
-    public void onFragmentInteraction(String id) {
-
     }
 
     /**

--- a/app/src/main/java/com/voipgrid/vialer/MainActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/MainActivity.java
@@ -9,6 +9,7 @@ import com.google.android.material.tabs.TabLayout;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.core.content.ContextCompat;
 import androidx.viewpager.widget.ViewPager;
@@ -216,14 +217,17 @@ public class MainActivity extends NavigationDrawerActivity implements View.OnCli
         tabLayout.addTab(tabLayout.newTab().setText(R.string.tab_title_recents));
         tabLayout.addTab(tabLayout.newTab().setText(R.string.tab_title_missed));
 
-        mViewPager = (ViewPager) findViewById(R.id.view_pager);
+        TabAdapter adapter = new TabAdapter(getSupportFragmentManager());
+        mViewPager = findViewById(R.id.view_pager);
         mViewPager.addOnPageChangeListener(new TabLayout.TabLayoutOnPageChangeListener(tabLayout));
-        mViewPager.setAdapter(new TabAdapter(getSupportFragmentManager()));
+        mViewPager.setAdapter(adapter);
 
         tabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
             @Override
             public void onTabSelected(TabLayout.Tab tab) {
                 mViewPager.setCurrentItem(tab.getPosition());
+
+                ((CallRecordFragment) adapter.getItem(tab.getPosition())).fragmentIsVisible();
 
                 // Get tracker.
                 Tracker tracker = ((AnalyticsApplication) getApplication()).getDefaultTracker();
@@ -297,7 +301,7 @@ public class MainActivity extends NavigationDrawerActivity implements View.OnCli
     /**
      * Tab adapter to handle tabs in the ViewPager
      */
-    public class TabAdapter extends FragmentStatePagerAdapter {
+    public class TabAdapter extends FragmentPagerAdapter {
 
         public TabAdapter(FragmentManager fragmentManager) {
             super(fragmentManager);
@@ -305,11 +309,11 @@ public class MainActivity extends NavigationDrawerActivity implements View.OnCli
 
         @Override
         public Fragment getItem(int position) {
-            if(position == 0) { // recents tab
-                return CallRecordFragment.newInstance(null);
+            if(position == 0) {
+                return CallRecordFragment.mine();
             }
-            if(position == 1) { // missed tab
-                return CallRecordFragment.newInstance(CallRecordFragment.FILTER_MISSED_RECORDS);
+            if(position == 1) {
+                return CallRecordFragment.all();
             }
             return TabFragment.newInstance("");
         }

--- a/app/src/main/java/com/voipgrid/vialer/MainActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/MainActivity.java
@@ -227,8 +227,6 @@ public class MainActivity extends NavigationDrawerActivity implements View.OnCli
             public void onTabSelected(TabLayout.Tab tab) {
                 mViewPager.setCurrentItem(tab.getPosition());
 
-                ((CallRecordFragment) adapter.getItem(tab.getPosition())).fragmentIsVisible();
-
                 // Get tracker.
                 Tracker tracker = ((AnalyticsApplication) getApplication()).getDefaultTracker();
 

--- a/app/src/main/java/com/voipgrid/vialer/NavigationDrawerActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/NavigationDrawerActivity.java
@@ -20,6 +20,7 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.Toolbar;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,6 +34,7 @@ import com.voipgrid.vialer.api.Api;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.Destination;
 import com.voipgrid.vialer.api.models.FixedDestination;
+import com.voipgrid.vialer.api.models.InternalNumbers;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SelectedUserDestinationParams;
 import com.voipgrid.vialer.api.models.SystemUser;
@@ -44,6 +46,8 @@ import com.voipgrid.vialer.util.JsonStorage;
 import com.voipgrid.vialer.util.LoginRequiredActivity;
 import com.voipgrid.vialer.middleware.MiddlewareHelper;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import retrofit2.Call;
@@ -186,7 +190,7 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
                 PackageInfo packageInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
                 String version = packageInfo.versionName;
                 if (version.contains("beta")) {
-                    textView.setText(getString(R.string.version_info_beta, version, packageInfo.versionCode));
+                    textView.setText(getString(R.string.version_info_beta, version, String.valueOf(packageInfo.versionCode)));
                 } else {
                     textView.setText(getString(R.string.version_info, version));
                 }
@@ -338,6 +342,8 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
                 return;
             }
 
+            storeInternalNumbers(userDestinationObjects);
+
             UserDestination userDestination = userDestinationObjects.get(0);
 
             // Create not available destination.
@@ -376,6 +382,24 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
             mSpinnerAdapter.notifyDataSetChanged();
             mSpinner.setSelection(activeIndex);
         }
+    }
+
+    /**
+     * Store a list of internal numbers to storage.
+     *
+     * @param userDestinationObjects
+     */
+    private void storeInternalNumbers(List<UserDestination> userDestinationObjects) {
+        InternalNumbers internalNumbers = new InternalNumbers();
+        for (UserDestination userDestination : userDestinationObjects) {
+            internalNumbers.add(userDestination.getInternalNumber());
+
+            for (PhoneAccount phoneAccount : userDestination.getPhoneAccounts()) {
+                internalNumbers.add(phoneAccount.getNumber());
+            }
+        }
+
+        mJsonStorage.save(internalNumbers);
     }
 
     private static class CustomFontSpinnerAdapter<D> extends ArrayAdapter {

--- a/app/src/main/java/com/voipgrid/vialer/Preferences.java
+++ b/app/src/main/java/com/voipgrid/vialer/Preferences.java
@@ -30,7 +30,7 @@ public class Preferences {
     public static final String PREF_HAS_TLS_ENABLED = "PREF_HAS_TLS_ENABLED";
     public static final String PREF_HAS_STUN_ENABLED = "PREF_HAS_STUN_ENABLED";
     public static final String PREF_AUDIO_CODEC = "PREF_AUDIO_CODEC";
-    public static final String PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT = "PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT";
+    public static final String PREF_DISPLAY_MISSED_CALLS_ONLY = "PREF_DISPLAY_MISSED_CALLS_ONLY";
 
     public static final String CONNECTION_PREFERENCE = "CONNECTION_PREFERENCE";
     public static final long CONNECTION_PREFERENCE_NONE = -10;
@@ -204,11 +204,11 @@ public class Preferences {
         return mPreferences.getInt(PREF_AUDIO_CODEC, DEFAULT_VALUE_AUDIO_CODEC);
     }
 
-    public boolean getDisplayCallRecordsForWholeClient() {
-        return mPreferences.getBoolean(PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT, false);
+    public boolean getDisplayMissedCallsOnly() {
+        return mPreferences.getBoolean(PREF_DISPLAY_MISSED_CALLS_ONLY, false);
     }
 
-    public void setDisplayCallRecordsForWholeClient(boolean displayCallRecordsForWholeClient) {
-        mPreferences.edit().putBoolean(PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT, displayCallRecordsForWholeClient).apply();
+    public void setDisplayMissedCallsOnly(boolean displayMissedCallsOnly) {
+        mPreferences.edit().putBoolean(PREF_DISPLAY_MISSED_CALLS_ONLY, displayMissedCallsOnly).apply();
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/Preferences.java
+++ b/app/src/main/java/com/voipgrid/vialer/Preferences.java
@@ -30,6 +30,7 @@ public class Preferences {
     public static final String PREF_HAS_TLS_ENABLED = "PREF_HAS_TLS_ENABLED";
     public static final String PREF_HAS_STUN_ENABLED = "PREF_HAS_STUN_ENABLED";
     public static final String PREF_AUDIO_CODEC = "PREF_AUDIO_CODEC";
+    public static final String PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT = "PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT";
 
     public static final String CONNECTION_PREFERENCE = "CONNECTION_PREFERENCE";
     public static final long CONNECTION_PREFERENCE_NONE = -10;
@@ -201,5 +202,13 @@ public class Preferences {
 
     public @AudioCodec int getAudioCodec() {
         return mPreferences.getInt(PREF_AUDIO_CODEC, DEFAULT_VALUE_AUDIO_CODEC);
+    }
+
+    public boolean getDisplayCallRecordsForWholeClient() {
+        return mPreferences.getBoolean(PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT, false);
+    }
+
+    public void setDisplayCallRecordsForWholeClient(boolean displayCallRecordsForWholeClient) {
+        mPreferences.edit().putBoolean(PREF_DISPLAY_CALL_RECORDS_FOR_WHOLE_CLIENT, displayCallRecordsForWholeClient).apply();
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/VialerApplication.java
+++ b/app/src/main/java/com/voipgrid/vialer/VialerApplication.java
@@ -33,7 +33,7 @@ public class VialerApplication extends AnalyticsApplication {
         sApplication = this;
         mActivityLifecycle = new ActivityLifecycleTracker();
         registerActivityLifecycleCallbacks(mActivityLifecycle);
-        //new ANRWatchDog().start();
+        new ANRWatchDog().start();
         Contacts.initialize(this);
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/VialerApplication.java
+++ b/app/src/main/java/com/voipgrid/vialer/VialerApplication.java
@@ -33,7 +33,7 @@ public class VialerApplication extends AnalyticsApplication {
         sApplication = this;
         mActivityLifecycle = new ActivityLifecycleTracker();
         registerActivityLifecycleCallbacks(mActivityLifecycle);
-        new ANRWatchDog().start();
+        //new ANRWatchDog().start();
         Contacts.initialize(this);
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/api/Api.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/Api.java
@@ -64,6 +64,11 @@ public interface Api {
                                                       @Query("offset") int offset,
                                                       @Query("call_date__gt") String date);
 
+    @GET("api/cdr/record/personalized/")
+    Call<VoipGridResponse<CallRecord>> getRecentCallsForLoggedInUser(@Query("limit") int limit,
+            @Query("offset") int offset,
+            @Query("call_date__gt") String date);
+
     @GET("api/userdestination/")
     Call<VoipGridResponse<UserDestination>> getUserDestination();
 

--- a/app/src/main/java/com/voipgrid/vialer/api/ServiceGenerator.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/ServiceGenerator.java
@@ -7,6 +7,7 @@ import com.google.gson.GsonBuilder;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.api.interceptors.AddAuthorizationCredentialsToRequest;
 import com.voipgrid.vialer.api.interceptors.AddUserAgentToHeader;
+import com.voipgrid.vialer.api.interceptors.LogResponsesToConsole;
 import com.voipgrid.vialer.api.interceptors.LogUserOutOnUnauthorizedResponse;
 import com.voipgrid.vialer.api.interceptors.ModifyCacheLifetimeBasedOnConnectivity;
 import com.voipgrid.vialer.util.AccountHelper;
@@ -49,6 +50,7 @@ public class ServiceGenerator {
         httpClient.addInterceptor(new AddUserAgentToHeader(context));
         httpClient.addInterceptor(new ModifyCacheLifetimeBasedOnConnectivity(context));
         httpClient.addInterceptor(new LogUserOutOnUnauthorizedResponse(context));
+        httpClient.addInterceptor(new LogResponsesToConsole());
 
         httpClient.cache(getCache(context));
 

--- a/app/src/main/java/com/voipgrid/vialer/api/interceptors/LogResponsesToConsole.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/interceptors/LogResponsesToConsole.java
@@ -1,0 +1,36 @@
+package com.voipgrid.vialer.api.interceptors;
+
+import android.util.Log;
+
+import com.google.gson.GsonBuilder;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class LogResponsesToConsole implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+
+        Response response = chain.proceed(request);
+        String body = response.body().string();
+
+        try {
+            JSONObject jsonObject = new JSONObject(body);
+            Log.d("HTTP", "Response from " + request.url() + ": " + jsonObject.toString(2));
+        } catch (JSONException e) {
+            Log.e("HTTP", "Unable to format JSON: " + body);
+        }
+
+        return response.newBuilder()
+                .body(ResponseBody.create(response.body().contentType(), body)).build();
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/api/models/CallRecord.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/models/CallRecord.java
@@ -124,13 +124,21 @@ public class CallRecord {
         return destinationCode.equals(INTERNAL_DESTINATION_CODE) || destinationCode.equals(SIP_DESTINATION_CODE);
     }
 
+    public boolean isInbound() {
+        return getDirection().equals(DIRECTION_INBOUND);
+    }
+
+    public boolean isOutbound() {
+        return getDirection().equals(DIRECTION_OUTBOUND);
+    }
+
     /**
      * Check if this was a missed call.
      *
      * @return TRUE if missed call, otherwise FALSE.
      */
     public boolean wasMissed() {
-        return getDirection().equals(CallRecord.DIRECTION_INBOUND) && getDuration() == 0;
+        return isInbound() && getDuration() == 0;
     }
 
     public long getId() {

--- a/app/src/main/java/com/voipgrid/vialer/api/models/CallRecord.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/models/CallRecord.java
@@ -13,7 +13,6 @@ public class CallRecord {
 
     public static final String DIRECTION_OUTBOUND = "outbound";
     public static final String DIRECTION_INBOUND = "inbound";
-    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
     private static final String CALL_DATE_FORMAT = "yyyy-MM-dd";
 

--- a/app/src/main/java/com/voipgrid/vialer/api/models/InternalNumbers.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/models/InternalNumbers.java
@@ -1,0 +1,6 @@
+package com.voipgrid.vialer.api.models;
+
+import java.util.ArrayList;
+
+public class InternalNumbers extends ArrayList<String> {
+}

--- a/app/src/main/java/com/voipgrid/vialer/api/models/UserDestination.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/models/UserDestination.java
@@ -7,9 +7,6 @@ import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Created by eltjo on 16/09/15.
- */
 public class UserDestination {
 
     @SerializedName("fixeddestinations")
@@ -23,6 +20,9 @@ public class UserDestination {
 
     @SerializedName("id")
     private String id;
+
+    @SerializedName("internal_number")
+    private String internalNumber;
 
     public List<FixedDestination> getFixedDestinations() {
         return fixedDestinations;
@@ -98,5 +98,9 @@ public class UserDestination {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getInternalNumber() {
+        return internalNumber;
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CachedContacts.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CachedContacts.java
@@ -1,0 +1,50 @@
+package com.voipgrid.vialer.callrecord;
+
+import android.graphics.Bitmap;
+import android.util.Log;
+
+import com.github.tamir7.contacts.Contact;
+import com.voipgrid.vialer.VialerApplication;
+import com.voipgrid.vialer.contacts.Contacts;
+import com.voipgrid.vialer.permissions.ContactsPermission;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+
+public class CachedContacts {
+
+    private final Map<String, Contact> contactsCache = new HashMap<>();
+    private final Map<String, Bitmap> contactImagesCache = new HashMap<>();
+
+    private final Contacts contacts;
+
+    public CachedContacts(Contacts contacts) {
+        this.contacts = contacts;
+    }
+
+    @Nullable Contact getContact(String number) {
+        if (!ContactsPermission.hasPermission(VialerApplication.get())) {
+            return null;
+        }
+
+        if (!contactsCache.containsKey(number)) {
+            contactsCache.put(number, contacts.getContactByPhoneNumber(number));
+        }
+
+        return contactsCache.get(number);
+    }
+
+    @Nullable Bitmap getContactImage(String number) {
+        if (!ContactsPermission.hasPermission(VialerApplication.get())) {
+            return null;
+        }
+
+        if (!contactImagesCache.containsKey(number)) {
+            contactImagesCache.put(number, contacts.getContactImageByPhoneNumber(number));
+        }
+
+        return contactImagesCache.get(number);
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
@@ -22,10 +22,8 @@ import com.voipgrid.vialer.permissions.ContactsPermission;
 import com.voipgrid.vialer.util.DialHelper;
 import com.voipgrid.vialer.util.IconHelper;
 import com.voipgrid.vialer.util.PhoneNumberUtils;
+import com.voipgrid.vialer.util.TimeUtils;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +152,7 @@ public class CallRecordAdapter extends BaseAdapter implements View.OnClickListen
                 R.id.text_view_contact_information
         );
 
-        ImageButton callButton = (ImageButton) convertView.findViewById(R.id.call_record_call_button);
+        ImageButton callButton = convertView.findViewById(R.id.call_record_call_button);
 
         // Store the holder with the view.
         convertView.setTag(viewHolder);
@@ -178,19 +176,14 @@ public class CallRecordAdapter extends BaseAdapter implements View.OnClickListen
             // Set the compound drawable to the view.
             viewHolder.information.setCompoundDrawablesWithIntrinsicBounds(resource, 0, 0, 0);
 
-            // Format the date.
-            SimpleDateFormat dateFormat = new SimpleDateFormat(CallRecord.DATE_FORMAT);
-            Date date = null;
-            try {
-                date = dateFormat.parse(callRecord.getCallDate());
-            } catch (ParseException e) {
-                e.printStackTrace();
-            }
-
-            // Set the call record date information to the view.
             viewHolder.information.setText(DateUtils.getRelativeDateTimeString(
-                    mActivity, date.getTime(), DateUtils.SECOND_IN_MILLIS,
-                    DateUtils.YEAR_IN_MILLIS, DateUtils.FORMAT_ABBREV_TIME));
+                    mActivity,
+                    TimeUtils.convertToSystemTime(callRecord.getCallDate()),
+                    DateUtils.SECOND_IN_MILLIS,
+                    DateUtils.YEAR_IN_MILLIS,
+                    DateUtils.FORMAT_ABBREV_TIME
+            ));
+
         }
         return convertView;
     }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
@@ -40,7 +40,7 @@ import okhttp3.Cache;
 /**
  * Adapter to display the call records
  */
-public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordAdapter.CallRecordViewHolder> {
+public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordViewHolder> {
 
     private static final DiffUtil.ItemCallback<CallRecord> DIFF_CALLBACK =
             new DiffUtil.ItemCallback<CallRecord>() {
@@ -54,15 +54,11 @@ public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordAd
                 }
             };
 
-    private final Context context;
     private final CachedContacts contacts;
     private Activity activity;
 
-    private boolean mCallAlreadySetup = false;
-
-    public CallRecordAdapter(Context context, CachedContacts contacts) {
+    public CallRecordAdapter(CachedContacts contacts) {
         super(DIFF_CALLBACK);
-        this.context = context;
         this.contacts = contacts;
     }
 
@@ -80,6 +76,7 @@ public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordAd
 
         if (callRecord == null) return;
 
+        holder.provideDependencies(activity, contacts);
         holder.update(callRecord);
     }
 
@@ -87,108 +84,5 @@ public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordAd
         this.activity = activity;
 
         return this;
-    }
-
-    class CallRecordViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
-
-        CircleImageView contactIcon;
-        TextView contactName, contactInformation;
-        ImageButton callButton;
-        CallRecord callRecord;
-
-        CallRecordViewHolder(@NonNull View view) {
-            super(view);
-            contactIcon = view.findViewById(R.id.text_view_contact_icon);
-            contactName = view.findViewById(R.id.text_view_contact_name);
-            contactInformation = view.findViewById(R.id.text_view_contact_information);
-            callButton = view.findViewById(R.id.call_record_call_button);
-        }
-
-        /**
-         * Update this view based on the call record.
-         *
-         * @param callRecord
-         */
-        public void update(CallRecord callRecord) {
-            this.callRecord = callRecord;
-            String number = callRecord.getThirdPartyNumber();
-            Contact contact = contacts.getContact(number);
-            contactIcon.setImageBitmap(getContactImage(number, contact));
-            setNumberAndCallButtonVisibility(callRecord, contact);
-            contactInformation.setCompoundDrawablesWithIntrinsicBounds(getIcon(callRecord), 0, 0, 0);
-            contactInformation.setText(DateUtils.getRelativeDateTimeString(
-                    context,
-                    TimeUtils.convertToSystemTime(callRecord.getCallDate()),
-                    DateUtils.SECOND_IN_MILLIS,
-                    DateUtils.YEAR_IN_MILLIS,
-                    DateUtils.FORMAT_ABBREV_TIME
-            ));
-        }
-
-        private void setNumberAndCallButtonVisibility(CallRecord callRecord, @Nullable Contact contact) {
-            if(callRecord.isAnonymous()) {
-                contactName.setText(context.getString(R.string.supressed_number));
-                callButton.setVisibility(View.GONE);
-                return;
-            }
-
-            callButton.setOnClickListener(this);
-
-            if (contact != null) {
-                contactName.setText(contact.getDisplayName());
-                callButton.setVisibility(View.VISIBLE);
-                return;
-            }
-
-            contactName.setText(callRecord.getThirdPartyNumber());
-            callButton.setVisibility(View.VISIBLE);
-        }
-
-        /**
-         * Attempt to find the contact's image, falling back to a generic icon if
-         * none is available.
-         *
-         * @param number
-         * @param contact
-         * @return
-         */
-        private Bitmap getContactImage(String number, @Nullable Contact contact) {
-            if (contact == null) {
-                return IconHelper.getCallerIconBitmap("", number, 0);
-            }
-
-            Bitmap contactImage = contacts.getContactImage(number);
-
-            if (contactImage != null) {
-                return contactImage;
-            }
-
-            return IconHelper.getCallerIconBitmap(contact.getDisplayName().substring(0, 1), number, 0);
-        }
-
-        /**
-         * Determine the correct call icon to display.
-         *
-         * @param callRecord
-         * @return
-         */
-        private int getIcon(CallRecord callRecord) {
-            if (callRecord.getDirection().equals(CallRecord.DIRECTION_OUTBOUND)) {
-                return R.drawable.ic_outgoing;
-            }
-
-            return callRecord.getDuration() == 0 ? R.drawable.ic_incoming_missed : R.drawable.ic_incoming;
-        }
-
-        @Override
-        public void onClick(View view) {
-            if (callRecord.getThirdPartyNumber() != null && !mCallAlreadySetup) {
-                mCallAlreadySetup = true;
-                DialHelper.fromActivity(activity).callNumber(callRecord.getThirdPartyNumber(), "");
-                PreferenceManager.getDefaultSharedPreferences(context).edit().putString(DialerActivity.LAST_DIALED, callRecord.getThirdPartyNumber()).apply();
-            }
-
-            mCallAlreadySetup = false;
-        }
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordAdapter.java
@@ -1,13 +1,13 @@
 package com.voipgrid.vialer.callrecord;
 
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.preference.PreferenceManager;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -25,198 +25,170 @@ import com.voipgrid.vialer.util.PhoneNumberUtils;
 import com.voipgrid.vialer.util.TimeUtils;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.paging.PagedListAdapter;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.RecyclerView;
 import de.hdodenhof.circleimageview.CircleImageView;
+import okhttp3.Cache;
 
 /**
  * Adapter to display the call records
  */
-public class CallRecordAdapter extends BaseAdapter implements View.OnClickListener {
+public class CallRecordAdapter extends PagedListAdapter<CallRecord, CallRecordAdapter.CallRecordViewHolder> {
 
-    private List<CallRecord> mCallRecords;
+    private static final DiffUtil.ItemCallback<CallRecord> DIFF_CALLBACK =
+            new DiffUtil.ItemCallback<CallRecord>() {
+                @Override
+                public boolean areItemsTheSame(CallRecord oldItem, CallRecord newItem) {
+                    return oldItem.getId() == newItem.getId();
+                }
+                @Override
+                public boolean areContentsTheSame(CallRecord oldItem, CallRecord newItem) {
+                    return areItemsTheSame(oldItem, newItem);
+                }
+            };
 
-    private Activity mActivity;
+    private final Context context;
+    private final CachedContacts contacts;
+    private Activity activity;
 
-    public boolean mCallAlreadySetup = false;
+    private boolean mCallAlreadySetup = false;
 
-    private Map<String, Contact> mCachedContacts = new HashMap<>();
-    private Map<String, Bitmap> mCachedContactImages = new HashMap<>();
-
-    @Inject Contacts mContacts;
-
-    /**
-     * Construct a new CallRecordAdapter
-     * @param activity
-     * @param callRecords
-     */
-    CallRecordAdapter(Activity activity, List<CallRecord> callRecords) {
-        mActivity = activity;
-        mCallRecords = callRecords;
-        VialerApplication.get().component().inject(this);
+    public CallRecordAdapter(Context context, CachedContacts contacts) {
+        super(DIFF_CALLBACK);
+        this.context = context;
+        this.contacts = contacts;
     }
 
-    /**
-     * Set call records to the adapter
-     * @param callRecords
-     */
-    void setCallRecords(List<CallRecord> callRecords) {
-        mCallRecords = callRecords;
-        notifyDataSetChanged();
+    @NonNull
+    @Override
+    public CallRecordViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int i) {
+        View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_call_record, parent, false);
+
+        return new CallRecordViewHolder(itemView);
     }
 
     @Override
-    public int getCount() {
-        return mCallRecords.size();
-    }
-
-    @Override
-    public CallRecord getItem(int position) {
-        return mCallRecords.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return 0;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        ViewHolder viewHolder;
-        // Get the call record.
+    public void onBindViewHolder(@NonNull CallRecordViewHolder holder, int position) {
         CallRecord callRecord = getItem(position);
-        Contact contact = null;
-        String number = "";
-        // Default resource for direction.
-        int resource = 0;
 
-        if(callRecord != null) {
-            // Get the direction from the call record.
-            String direction = callRecord.getDirection();
+        if (callRecord == null) return;
 
-            // Set the drawable resource.
-            if (direction.equals(CallRecord.DIRECTION_OUTBOUND)) {
-                number = callRecord.getDialedNumber();
-                resource = R.drawable.ic_outgoing;
-            } else if (direction.equals(CallRecord.DIRECTION_INBOUND)) {
-                number = callRecord.getCaller();
-                if (callRecord.getDuration() == 0) {
-                    resource = R.drawable.ic_incoming_missed;
-                } else {
-                    resource = R.drawable.ic_incoming;
-                }
-            }
+        holder.update(callRecord);
+    }
 
-            // Get possible name or null.
-            if (ContactsPermission.hasPermission(mActivity)) {
-                if (!mCachedContacts.containsKey(number)) {
-                    mCachedContacts.put(number, mContacts.getContactByPhoneNumber(number));
-                }
-                contact = mCachedContacts.get(number);
-            }
+    public CallRecordAdapter setActivity(Activity activity) {
+        this.activity = activity;
+
+        return this;
+    }
+
+    class CallRecordViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+
+        CircleImageView contactIcon;
+        TextView contactName, contactInformation;
+        ImageButton callButton;
+        CallRecord callRecord;
+
+        CallRecordViewHolder(@NonNull View view) {
+            super(view);
+            contactIcon = view.findViewById(R.id.text_view_contact_icon);
+            contactName = view.findViewById(R.id.text_view_contact_name);
+            contactInformation = view.findViewById(R.id.text_view_contact_information);
+            callButton = view.findViewById(R.id.call_record_call_button);
         }
 
-        if(convertView == null) {
-            // Inflate the layout.
-            LayoutInflater inflater = mActivity.getLayoutInflater();
-            convertView = inflater.inflate(R.layout.list_item_call_record, parent, false);
-        }
-
-        Bitmap bitmapImage = null;
-
-        if (contact != null) {
-
-            if (!mCachedContactImages.containsKey(number)) {
-                mCachedContactImages.put(number, mContacts.getContactImageByPhoneNumber(number));
-            }
-
-            bitmapImage = mCachedContactImages.get(number);
-
-            if (bitmapImage == null) {
-                bitmapImage = IconHelper.getCallerIconBitmap(contact.getDisplayName().substring(0, 1), number, 0);
-            }
-        } else {
-            bitmapImage = IconHelper.getCallerIconBitmap("", number, 0);
-        }
-
-        View photoView = convertView.findViewById(R.id.text_view_contact_icon);
-
-        ((CircleImageView) photoView).setImageBitmap(bitmapImage);
-        // Set up the ViewHolder.
-        viewHolder = new ViewHolder();
-        viewHolder.title = (TextView) convertView.findViewById(R.id.text_view_contact_name);
-        viewHolder.information = (TextView) convertView.findViewById(
-                R.id.text_view_contact_information
-        );
-
-        ImageButton callButton = convertView.findViewById(R.id.call_record_call_button);
-
-        // Store the holder with the view.
-        convertView.setTag(viewHolder);
-
-        if(callRecord != null) {
-            // Set name or number as text.
-            if(number != null && PhoneNumberUtils.isAnonymousNumber(callRecord.getCaller())) {
-                viewHolder.title.setText(convertView.getContext().getString(R.string.supressed_number));
-                // Make call button invisible.
-                callButton.setVisibility(View.GONE);
-            } else if (contact != null) {
-                viewHolder.title.setText(contact.getDisplayName());
-                callButton.setOnClickListener(this);
-                callButton.setVisibility(View.VISIBLE);
-            } else {
-                viewHolder.title.setText(number);
-                callButton.setOnClickListener(this);
-                callButton.setVisibility(View.VISIBLE);
-            }
-
-            // Set the compound drawable to the view.
-            viewHolder.information.setCompoundDrawablesWithIntrinsicBounds(resource, 0, 0, 0);
-
-            viewHolder.information.setText(DateUtils.getRelativeDateTimeString(
-                    mActivity,
+        /**
+         * Update this view based on the call record.
+         *
+         * @param callRecord
+         */
+        public void update(CallRecord callRecord) {
+            this.callRecord = callRecord;
+            String number = callRecord.getThirdPartyNumber();
+            Contact contact = contacts.getContact(number);
+            contactIcon.setImageBitmap(getContactImage(number, contact));
+            setNumberAndCallButtonVisibility(callRecord, contact);
+            contactInformation.setCompoundDrawablesWithIntrinsicBounds(getIcon(callRecord), 0, 0, 0);
+            contactInformation.setText(DateUtils.getRelativeDateTimeString(
+                    context,
                     TimeUtils.convertToSystemTime(callRecord.getCallDate()),
                     DateUtils.SECOND_IN_MILLIS,
                     DateUtils.YEAR_IN_MILLIS,
                     DateUtils.FORMAT_ABBREV_TIME
             ));
-
-        }
-        return convertView;
-    }
-
-    @Override
-    public void onClick(View view) {
-        // Get the position of the list item the buttons is clicked for.
-        View parentRow = (View) view.getParent();
-        ListView listView = (ListView) parentRow.getParent();
-        final int position = listView.getPositionForView(parentRow);
-
-        // Get the call record.
-        CallRecord callRecord = getItem(position);
-        String direction = callRecord.getDirection();
-        String numberToCall = null;
-
-        // Determine direction and the number we need to call.
-        if (direction.equals(CallRecord.DIRECTION_OUTBOUND)) {
-            numberToCall = callRecord.getDialedNumber();
-        } else if (direction.equals(CallRecord.DIRECTION_INBOUND)) {
-            numberToCall = callRecord.getCaller();
         }
 
-        if (numberToCall != null && !mCallAlreadySetup) {
-            mCallAlreadySetup = true;
-            DialHelper.fromActivity(mActivity).callNumber(numberToCall, "");
-            PreferenceManager.getDefaultSharedPreferences(mActivity).edit().putString(DialerActivity.LAST_DIALED, numberToCall).apply();
+        private void setNumberAndCallButtonVisibility(CallRecord callRecord, @Nullable Contact contact) {
+            if(callRecord.isAnonymous()) {
+                contactName.setText(context.getString(R.string.supressed_number));
+                callButton.setVisibility(View.GONE);
+                return;
+            }
+
+            callButton.setOnClickListener(this);
+
+            if (contact != null) {
+                contactName.setText(contact.getDisplayName());
+                callButton.setVisibility(View.VISIBLE);
+                return;
+            }
+
+            contactName.setText(callRecord.getThirdPartyNumber());
+            callButton.setVisibility(View.VISIBLE);
         }
+
+        /**
+         * Attempt to find the contact's image, falling back to a generic icon if
+         * none is available.
+         *
+         * @param number
+         * @param contact
+         * @return
+         */
+        private Bitmap getContactImage(String number, @Nullable Contact contact) {
+            if (contact == null) {
+                return IconHelper.getCallerIconBitmap("", number, 0);
+            }
+
+            Bitmap contactImage = contacts.getContactImage(number);
+
+            if (contactImage != null) {
+                return contactImage;
+            }
+
+            return IconHelper.getCallerIconBitmap(contact.getDisplayName().substring(0, 1), number, 0);
+        }
+
+        /**
+         * Determine the correct call icon to display.
+         *
+         * @param callRecord
+         * @return
+         */
+        private int getIcon(CallRecord callRecord) {
+            if (callRecord.getDirection().equals(CallRecord.DIRECTION_OUTBOUND)) {
+                return R.drawable.ic_outgoing;
+            }
+
+            return callRecord.getDuration() == 0 ? R.drawable.ic_incoming_missed : R.drawable.ic_incoming;
+        }
+
+        @Override
+        public void onClick(View view) {
+            if (callRecord.getThirdPartyNumber() != null && !mCallAlreadySetup) {
+                mCallAlreadySetup = true;
+                DialHelper.fromActivity(activity).callNumber(callRecord.getThirdPartyNumber(), "");
+                PreferenceManager.getDefaultSharedPreferences(context).edit().putString(DialerActivity.LAST_DIALED, callRecord.getThirdPartyNumber()).apply();
+            }
+
             mCallAlreadySetup = false;
-    }
-
-    static class ViewHolder {
-        TextView title;
-        TextView information;
+        }
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
@@ -1,0 +1,99 @@
+package com.voipgrid.vialer.callrecord;
+
+import android.util.Log;
+
+import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.api.models.VoipGridResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+
+import androidx.annotation.NonNull;
+import androidx.paging.PositionalDataSource;
+import retrofit2.Response;
+
+public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
+
+    private final Api api;
+
+    CallRecordDataSource(Api api) {
+        this.api = api;
+    }
+
+    /**
+     * The total number of records that are available to fetch from the api.
+     */
+    private int total;
+
+    /**
+     * If set to TRUE, calls from the entire account will be fetched.
+     *
+     */
+    private boolean fetchCallsFromEntireAccount = false;
+
+    /**
+     * Instruct the data source to fetch calls from the entire account.
+     *
+     */
+    public CallRecordDataSource fetchCallsFromEntireAccount() {
+        fetchCallsFromEntireAccount = true;
+        return this;
+    }
+
+    @Override
+    public void loadInitial(@NonNull LoadInitialParams params, @NonNull LoadInitialCallback<CallRecord> callback) {
+        List<CallRecord> records = fetch(params.pageSize, params.requestedStartPosition);
+
+        if (records == null) return;
+
+        callback.onResult(records, params.requestedStartPosition, total);
+    }
+
+    @Override
+    public void loadRange(@NonNull LoadRangeParams params, @NonNull LoadRangeCallback<CallRecord> callback) {
+        List<CallRecord> records = fetch(params.loadSize, params.startPosition);
+
+        if (records == null) return;
+
+        callback.onResult(records);
+    }
+
+    /**
+     * Query the VoIPGRID api for call records.
+     *
+     * @param size
+     * @param startPosition
+     * @return
+     */
+    private List<CallRecord> fetch(int size, int startPosition) {
+        try {
+            Response<VoipGridResponse<CallRecord>> call;
+
+            if (fetchCallsFromEntireAccount) {
+                call = api.getRecentCalls(size, startPosition, CallRecord.getLimitDate()).execute();
+            } else {
+                call = api.getRecentCallsForLoggedInUser(size, startPosition, CallRecord.getLimitDate()).execute();
+            }
+
+            if (!call.isSuccessful()) {
+                return null;
+            }
+
+            if (call.body() == null) {
+                return null;
+            }
+
+            List<CallRecord> records = call.body().getObjects();
+for(CallRecord callRecord : records) {
+    Log.e("TEST123", "RECORD: " + callRecord);
+}
+            total = call.body().getMeta().getTotalCount();
+
+            return records;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
@@ -86,9 +86,7 @@ public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
             }
 
             List<CallRecord> records = call.body().getObjects();
-for(CallRecord callRecord : records) {
-    Log.e("TEST123", "RECORD: " + callRecord);
-}
+
             total = call.body().getMeta().getTotalCount();
 
             return records;

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
@@ -37,7 +37,7 @@ public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
      * Instruct the data source to fetch calls from the entire account.
      *
      */
-    public CallRecordDataSource fetchCallsFromEntireAccount() {
+    CallRecordDataSource fetchCallsFromEntireAccount() {
         fetchCallsFromEntireAccount = true;
         return this;
     }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
@@ -7,6 +7,7 @@ import com.voipgrid.vialer.api.models.CallRecord;
 import com.voipgrid.vialer.api.models.VoipGridResponse;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -17,6 +18,8 @@ import retrofit2.Response;
 public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
 
     private final Api api;
+
+    private int code;
 
     CallRecordDataSource(Api api) {
         this.api = api;
@@ -77,12 +80,14 @@ public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
                 call = api.getRecentCallsForLoggedInUser(size, startPosition, CallRecord.getLimitDate()).execute();
             }
 
+            code = call.code();
+
             if (!call.isSuccessful()) {
-                return null;
+                return new ArrayList<>();
             }
 
             if (call.body() == null) {
-                return null;
+                return new ArrayList<>();
             }
 
             List<CallRecord> records = call.body().getObjects();
@@ -91,7 +96,12 @@ public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
 
             return records;
         } catch (IOException e) {
+            code = 500;
             return null;
         }
+    }
+
+    public int getLastCode() {
+        return code;
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSourceFactory.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSourceFactory.java
@@ -1,0 +1,40 @@
+package com.voipgrid.vialer.callrecord;
+
+import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.models.CallRecord;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.paging.DataSource;
+
+public class CallRecordDataSourceFactory extends DataSource.Factory<Integer, CallRecord> {
+
+    private final Api api;
+    private MutableLiveData<CallRecordDataSource> postLiveData;
+
+    private boolean fetchCallsFromEntireAccount = false;
+
+    public CallRecordDataSourceFactory(Api api) {
+        this.api = api;
+    }
+
+    @Override
+    public DataSource<Integer, CallRecord> create() {
+        CallRecordDataSource dataSource = new CallRecordDataSource(api);
+        if (fetchCallsFromEntireAccount) {
+            dataSource.fetchCallsFromEntireAccount();
+        }
+        postLiveData = new MutableLiveData<>();
+        postLiveData.postValue(dataSource);
+        return dataSource;
+    }
+
+    public CallRecordDataSourceFactory fetchCallsFromEntireAccount() {
+        fetchCallsFromEntireAccount = true;
+
+        return this;
+    }
+
+    public MutableLiveData<CallRecordDataSource> getPostLiveData() {
+        return postLiveData;
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
@@ -128,6 +128,5 @@ public class CallRecordFragment extends Fragment
     }
 
     public void fragmentIsVisible() {
-        Log.e("TEST123", "VISSISISBISBE");
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
@@ -1,95 +1,82 @@
 package com.voipgrid.vialer.callrecord;
 
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CompoundButton;
 
-import com.google.android.material.snackbar.Snackbar;
-import com.voipgrid.vialer.EmptyView;
-import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.VialerApplication;
-import com.voipgrid.vialer.api.Api;
-import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.CallRecord;
-import com.voipgrid.vialer.api.models.VoipGridResponse;
-import com.voipgrid.vialer.logging.Logger;
-import com.voipgrid.vialer.util.ConnectivityHelper;
-import com.voipgrid.vialer.util.JsonStorage;
+import com.voipgrid.vialer.contacts.Contacts;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
 
-import androidx.annotation.NonNull;
-import androidx.fragment.app.ListFragment;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
+import androidx.paging.LivePagedListBuilder;
+import androidx.paging.PagedList;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.OnCheckedChanged;
 import butterknife.Unbinder;
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
-/**
- * A fragment representing a list of call records.
- */
-public class CallRecordFragment extends ListFragment implements
-        Callback<VoipGridResponse<CallRecord>>,
-        SwipeRefreshLayout.OnRefreshListener {
 
-    private static final String ARG_FILTER = "filter";
-    public static final String FILTER_MISSED_RECORDS = "missed-records";
+public class CallRecordFragment extends Fragment
+        implements SwipeRefreshLayout.OnRefreshListener, Observer<PagedList<CallRecord>> {
 
-    private CallRecordAdapter mAdapter;
-    private List<CallRecord> mCallRecords = new ArrayList<>();
-    private SwipeRefreshLayout mSwipeRefreshLayout;
+    @Inject CallRecordDataSourceFactory factory;
+    @Inject CallRecordAdapter adapter;
 
-    @Inject ConnectivityHelper mConnectivityHelper;
-    @Inject JsonStorage mJsonStorage;
-    @Inject Preferences mPreferences;
+    @BindView(R.id.swipe_container) SwipeRefreshLayout swipeContainer;
+    @BindView(R.id.call_records) RecyclerView mRecyclerView;
 
-    private String mFilter;
-    private boolean mHaveNetworkRecords;
-    private Unbinder mUnbinder;
+    private Unbinder unbinder;
 
-    @BindView(R.id.show_calls_for_whole_client_switch) CompoundButton mShowCallsForWholeClientSwitch;
+    private boolean fetchCallsFromEntireAccount = false;
 
-    public static CallRecordFragment newInstance(String filter) {
-        CallRecordFragment fragment = new CallRecordFragment();
-        Bundle arguments = new Bundle();
-        arguments.putString(ARG_FILTER, filter);
-        fragment.setArguments(arguments);
-        return fragment;
+    /**
+     * The number of call records to fetch with each HTTP request.
+     */
+    private static final int CALL_RECORDS_PAGE_SIZE = 50;
+
+    /**
+     * Display only the user's calls.
+     *
+     */
+    public static CallRecordFragment mine() {
+        return new CallRecordFragment();
     }
 
     /**
-     * Mandatory empty constructor for the fragment manager to instantiate the
-     * fragment (e.g. upon screen orientation changes).
+     * Display the user's calls for the entire account.
+     *
      */
-    public CallRecordFragment() {
+    public static CallRecordFragment all() {
+        CallRecordFragment fragment = new CallRecordFragment();
+        fragment.fetchCallsFromEntireAccount = true;
+        return fragment;
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        VialerApplication.get().component().inject(this);
-        mFilter = getArguments().getString(ARG_FILTER);
-    }
-
-    @Override
-    public View onCreateView(
-            LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState
-    ) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_call_records, null);
-        mUnbinder = ButterKnife.bind(this, view);
+        VialerApplication.get().component().inject(this);
+        unbinder = ButterKnife.bind(this, view);
+
+        if (fetchCallsFromEntireAccount) {
+            factory.fetchCallsFromEntireAccount();
+        }
+
         return view;
     }
 
@@ -97,242 +84,50 @@ public class CallRecordFragment extends ListFragment implements
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mAdapter = new CallRecordAdapter(getActivity(), mCallRecords);
+        setupSwipeContainer();
+        setupRecyclerView();
 
-        /* setup swipe refresh layout */
-        mSwipeRefreshLayout = view.findViewById(R.id.swipe_container);
-        mSwipeRefreshLayout.setColorSchemeColors(getResources().getColor(R.color.color_refresh));
-        mSwipeRefreshLayout.setOnRefreshListener(this);
-        mSwipeRefreshLayout.post(() -> mSwipeRefreshLayout.setRefreshing(true));
-        loadCallRecordsFromApi();
-        loadCallRecordsFromCache();
-        getListView().setAdapter(mAdapter);
+        PagedList.Config config = new PagedList.Config.Builder().setPageSize(CALL_RECORDS_PAGE_SIZE).build();
+        new LivePagedListBuilder(factory, config).build().observe(this, this);
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-
-        // Check if wifi should be turned back on.
-        if(ConnectivityHelper.mWifiKilled) {
-            mConnectivityHelper.useWifi(getActivity(), true);
-            ConnectivityHelper.mWifiKilled = false;
-        }
-        mAdapter.mCallAlreadySetup = false;
+    private void setupSwipeContainer() {
+        swipeContainer.setColorSchemeColors(getResources().getColor(R.color.color_refresh));
+        swipeContainer.setOnRefreshListener(this);
+        swipeContainer.post(() -> swipeContainer.setRefreshing(true));
     }
 
-    @Override
-    public void setUserVisibleHint(boolean isVisibleToUser) {
-        super.setUserVisibleHint(isVisibleToUser);
-        if (mShowCallsForWholeClientSwitch != null) {
-            mShowCallsForWholeClientSwitch.setChecked(mPreferences.getDisplayCallRecordsForWholeClient());
-        }
-    }
-
-    @OnCheckedChanged(R.id.show_calls_for_whole_client_switch)
-    void showCallsForWholeClientSwitchWasChanged(CompoundButton view, boolean checked) {
-        Log.e("TEST123", "checke change");
-        mPreferences.setDisplayCallRecordsForWholeClient(checked);
-        clearCallRecordCache();
-        onRefresh();
-    }
-
-    /**
-     * Completely clear the call record cache so call records must be fetched from the API.
-     *
-     */
-    private void clearCallRecordCache() {
-        mJsonStorage.remove(CallRecord[].class);
+    private void setupRecyclerView() {
+        adapter.setActivity(getActivity());
+        mRecyclerView.setAdapter(adapter);
+        RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(VialerApplication.get());
+        mRecyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), LinearLayoutManager.VERTICAL));
+        mRecyclerView.setLayoutManager(mLayoutManager);
+        mRecyclerView.setItemAnimator(new DefaultItemAnimator());
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        mUnbinder.unbind();
+        unbinder.unbind();
     }
 
-    /**
-     * Perform a refresh action
-     */
     @Override
     public void onRefresh() {
-        loadCallRecordsFromApi();
-    }
-
-    private void loadCallRecordsFromApi() {
-        mHaveNetworkRecords = false;
-
-        Api api = ServiceGenerator.createApiService(getContext());
-
-        Call<VoipGridResponse<CallRecord>> call;
-
-        if (mPreferences.getDisplayCallRecordsForWholeClient()) {
-             call = api.getRecentCalls(50, 0, CallRecord.getLimitDate());
-        } else {
-            call = api.getRecentCallsForLoggedInUser(50, 0, CallRecord.getLimitDate());
-        }
-
-        call.enqueue(this);
-    }
-
-    /* Load from local cache first */
-    private void loadCallRecordsFromCache() {
-        new AsyncCallRecordLoader().execute();
-    }
-
-    private void displayCachedRecords(List<CallRecord> records) {
-        // Cached results arrived later than the network results.
-        if (mHaveNetworkRecords) {
-            return;
-        }
-        displayCallRecords(records);
-    }
-
-    private void displayCallRecords(List<CallRecord> records) {
-        List<CallRecord> filtered = filter(records);
-
-        if(filtered != null && filtered.size() > 0) {
-            mAdapter.setCallRecords(filtered);
-            setEmptyView(null, false);
-        } else if(filtered.size() == 0) {
-            mAdapter.setCallRecords(filtered);
-
-            setEmptyView(
-                    new EmptyView(
-                            getActivity(),
-                            isShowingMissedCallRecords() ? getString(R.string.empty_view_missed_message) : getString(R.string.empty_view_default_message)
-                    ),
-                    true
-            );
-        }
-        mSwipeRefreshLayout.setRefreshing(false);
-    }
-
-    /**
-     * Check if this call record fragment is meant to be showing missed call records rather than all call records.
-     *
-     * @return TRUE if fragment is showing missed calls, otherwise FALSE.
-     */
-    private boolean isShowingMissedCallRecords() {
-        return mFilter != null && mFilter.equals(FILTER_MISSED_RECORDS);
-    }
-
-    /**
-     * Apply filter on call records or return the call record list when the filter is null
-     * @param callRecords List of CallRecord instances
-     * @return List of CallRecord instances.
-     */
-    private List<CallRecord> filter(List<CallRecord> callRecords) {
-        if (!isShowingMissedCallRecords() || mFilter == null || callRecords == null || callRecords.size() <= 0) {
-            return callRecords;
-        }
-
-        List<CallRecord> filtered = new ArrayList<>();
-
-        for (CallRecord record : callRecords) {
-            if (record.wasMissed()) {
-                filtered.add(record);
-            }
-        }
-
-        return filtered;
-    }
-
-    @Override
-    public void onResponse(@NonNull Call<VoipGridResponse<CallRecord>> call,
-                           @NonNull Response<VoipGridResponse<CallRecord>> response) {
-        if (response.isSuccessful() && response.body() != null) {
-            mHaveNetworkRecords = true;
-            List<CallRecord> records = response.body().getObjects();
-
-            if(getActivity() != null && isAdded()) {
-                displayCallRecords(records);
-            }
-
-            // Save the records to cache, if there are any.
-            if (filter(records).size() > 0) {
-                new AsyncCallRecordSaver(records).execute();
-            }
-        } else {
-            failedFeedback(response);
-        }
-    }
-
-    @Override
-    public void onFailure(Call call, Throwable t) {
-        failedFeedback(null);
-    }
-
-    private void failedFeedback(Response response) {
-        if (getActivity() == null) {
-            new Logger(CallRecordFragment.class).e("CallRecordFragment is no longer attached to an activity");
+        if (factory == null || factory.getPostLiveData() == null || factory.getPostLiveData().getValue() == null) {
             return;
         }
 
-        String message = getString(R.string.empty_view_default_message);
-
-        // Check if authorized.
-        if(response != null && (response.code() == 401 || response.code() == 403)) {
-            message = getString(R.string.empty_view_unauthorized_message);
-        }
-        if (mAdapter.getCount() == 0) {
-            setEmptyView(new EmptyView(getActivity(), message), true);
-        } else {
-            // Adapter has cached values and we're not about to overwrite them. However,
-            // we do want to notify the user.
-            Snackbar.make(getView(), message, Snackbar.LENGTH_SHORT).show();
-        }
-        mSwipeRefreshLayout.setRefreshing(false);
+        factory.getPostLiveData().getValue().invalidate();
     }
 
-    private void setEmptyView(EmptyView emptyView, boolean visible) {
-        if(getView() != null) {
-            ViewGroup view = getView().findViewById(R.id.empty_view);
-            if (view.getChildCount() > 0) {
-                view.removeAllViews();
-            }
-            if (emptyView != null) {
-                view.addView(emptyView);
-            }
-            view.setVisibility(visible ? View.VISIBLE : View.GONE);
-        }
+    @Override
+    public void onChanged(PagedList<CallRecord> callRecords) {
+        adapter.submitList(callRecords);
+        swipeContainer.setRefreshing(false);
     }
 
-    private class AsyncCallRecordLoader extends AsyncTask<Void, Void, List<CallRecord>> {
-        private JsonStorage<CallRecord[]> mJsonStorage;
-        public AsyncCallRecordLoader() {
-            mJsonStorage = new JsonStorage<>(getActivity());
-        }
-
-        protected List<CallRecord> doInBackground(Void args[]) {
-            CallRecord[] records = mJsonStorage.get(CallRecord[].class);
-            if (records != null) {
-                return Arrays.asList(records);
-            } else {
-                return new ArrayList<>();
-            }
-        }
-
-        protected void onPostExecute(List<CallRecord> records) {
-            if(isAdded()){
-                // Only display Records when the fragment is still attached to an activity.
-                displayCachedRecords(records);
-            }
-        }
-    }
-
-    private class AsyncCallRecordSaver extends AsyncTask<Void, Void, Void> {
-        private List<CallRecord> mRecords;
-
-        public AsyncCallRecordSaver(List<CallRecord> records) {
-            mRecords = records;
-        }
-
-        protected Void doInBackground(Void args[]) {
-            CallRecord[] records = new CallRecord[mRecords.size()];
-            mRecords.toArray(records);
-            mJsonStorage.save(records);
-            return null;
-        }
+    public void fragmentIsVisible() {
+        Log.e("TEST123", "VISSISISBISBE");
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
@@ -1,27 +1,18 @@
 package com.voipgrid.vialer.callrecord;
 
-import android.app.Activity;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.fragment.app.ListFragment;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
-import android.widget.ListView;
-import android.widget.Switch;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.voipgrid.vialer.EmptyView;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.VialerApplication;
-import com.voipgrid.vialer.analytics.AnalyticsApplication;
-import com.voipgrid.vialer.analytics.AnalyticsHelper;
 import com.voipgrid.vialer.api.Api;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.CallRecord;
@@ -36,6 +27,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.ListFragment;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;
@@ -229,22 +223,19 @@ public class CallRecordFragment extends ListFragment implements
      * @return List of CallRecord instances.
      */
     private List<CallRecord> filter(List<CallRecord> callRecords) {
-        if (mFilter != null && callRecords != null && callRecords.size() > 0) {
-            List<CallRecord> filtered = new ArrayList<>();
-
-            if (isShowingMissedCallRecords()) {
-                for (int i=0, size = callRecords.size(); i < size; i++) {
-                    CallRecord callRecord = callRecords.get(i);
-
-                    if (callRecord.getDirection().equals(CallRecord.DIRECTION_INBOUND) &&
-                            callRecord.getDuration() == 0) {
-                        filtered.add(callRecord);
-                    }
-                }
-            }
-            return filtered;
+        if (!isShowingMissedCallRecords() || mFilter == null || callRecords == null || callRecords.size() <= 0) {
+            return callRecords;
         }
-        return callRecords;
+
+        List<CallRecord> filtered = new ArrayList<>();
+
+        for (CallRecord record : callRecords) {
+            if (record.wasMissed()) {
+                filtered.add(record);
+            }
+        }
+
+        return filtered;
     }
 
     @Override

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordFragment.java
@@ -1,15 +1,26 @@
 package com.voipgrid.vialer.callrecord;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
+import android.widget.Switch;
 
+import com.voipgrid.vialer.EmptyView;
+import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.VialerApplication;
+import com.voipgrid.vialer.api.Api;
 import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.api.models.VoipGridResponse;
 import com.voipgrid.vialer.contacts.Contacts;
+import com.voipgrid.vialer.util.BroadcastReceiverManager;
+import com.voipgrid.vialer.util.NetworkUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,17 +39,28 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.OnCheckedChanged;
 import butterknife.Unbinder;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 
 public class CallRecordFragment extends Fragment
-        implements SwipeRefreshLayout.OnRefreshListener, Observer<PagedList<CallRecord>> {
+        implements SwipeRefreshLayout.OnRefreshListener, Observer<PagedList<CallRecord>>, MissedCalls.Callback {
 
     @Inject CallRecordDataSourceFactory factory;
     @Inject CallRecordAdapter adapter;
+    @Inject MissedCalls mMissedCalls;
+    @Inject MissedCallsAdapter missedCallsAdapter;
+    @Inject Preferences mPreferences;
+    @Inject NetworkUtil mNetworkUtil;
+    @Inject BroadcastReceiverManager mBroadcastReceiverManager;
 
     @BindView(R.id.swipe_container) SwipeRefreshLayout swipeContainer;
     @BindView(R.id.call_records) RecyclerView mRecyclerView;
+    @BindView(R.id.show_missed_calls_only_switch) Switch showMissedCallsOnlySwitch;
+    @BindView(R.id.call_records_container) View mCallRecordsContainer;
 
     private Unbinder unbinder;
 
@@ -83,12 +105,27 @@ public class CallRecordFragment extends Fragment
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
+        setupMissedCallsAdapter();
+        setupCallRecordAdapter();
         setupSwipeContainer();
         setupRecyclerView();
+        showAppropriateRecords();
+        showMissedCallsOnlySwitch.setChecked(mPreferences.getDisplayMissedCallsOnly());
+        onRefresh();
+    }
 
+    private void showAppropriateRecords() {
+        mRecyclerView.setAdapter(showMissedCalls() ? missedCallsAdapter : adapter);
+    }
+
+    private void setupCallRecordAdapter() {
         PagedList.Config config = new PagedList.Config.Builder().setPageSize(CALL_RECORDS_PAGE_SIZE).build();
         new LivePagedListBuilder(factory, config).build().observe(this, this);
+        adapter.setActivity(getActivity());
+    }
+
+    private void setupMissedCallsAdapter() {
+        missedCallsAdapter.setActivity(getActivity());
     }
 
     private void setupSwipeContainer() {
@@ -98,8 +135,6 @@ public class CallRecordFragment extends Fragment
     }
 
     private void setupRecyclerView() {
-        adapter.setActivity(getActivity());
-        mRecyclerView.setAdapter(adapter);
         RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(VialerApplication.get());
         mRecyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), LinearLayoutManager.VERTICAL));
         mRecyclerView.setLayoutManager(mLayoutManager);
@@ -114,6 +149,21 @@ public class CallRecordFragment extends Fragment
 
     @Override
     public void onRefresh() {
+        if (!mNetworkUtil.isOnline()) {
+            mCallRecordsContainer.setVisibility(View.GONE);
+            setEmptyView(new EmptyView(getActivity(), getString(R.string.no_network_connection)), true);
+            return;
+        } else {
+            setEmptyView(null, false);
+        }
+
+        mCallRecordsContainer.setVisibility(View.VISIBLE);
+
+        if (showMissedCalls()) {
+            mMissedCalls.fetch(this, fetchCallsFromEntireAccount);
+            return;
+        }
+
         if (factory == null || factory.getPostLiveData() == null || factory.getPostLiveData().getValue() == null) {
             return;
         }
@@ -128,5 +178,67 @@ public class CallRecordFragment extends Fragment
     }
 
     public void fragmentIsVisible() {
+        if (mPreferences != null) {
+            showMissedCallsOnlySwitch.setChecked(mPreferences.getDisplayMissedCallsOnly());
+        }
+    }
+
+    @Override
+    public void missedCallsHaveBeenRetrieved(List<CallRecord> missedCallRecords) {
+        missedCallsAdapter.setRecords(missedCallRecords);
+        swipeContainer.setRefreshing(false);
+    }
+
+    @Override
+    public void attemptToRetrieveMissedCallsDidFail() {
+    }
+
+    private boolean showMissedCalls() {
+        return mPreferences.getDisplayMissedCallsOnly();
+    }
+
+    @OnCheckedChanged(R.id.show_missed_calls_only_switch)
+    void missedCallsSwitchWasChanged(CompoundButton missedCallsSwitch, boolean checked) {
+        mPreferences.setDisplayMissedCallsOnly(checked);
+        showAppropriateRecords();
+        swipeContainer.setRefreshing(true);
+        onRefresh();
+    }
+
+    private NetworkChangeReceiver mNetworkChangeReceiver = new NetworkChangeReceiver();
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mBroadcastReceiverManager.registerReceiverViaGlobalBroadcastManager(mNetworkChangeReceiver, "android.net.conn.CONNECTIVITY_CHANGE");
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mBroadcastReceiverManager.unregisterReceiver(mNetworkChangeReceiver);
+    }
+
+    private void setEmptyView(EmptyView emptyView, boolean visible) {
+        if(getView() != null) {
+            ViewGroup view = getView().findViewById(R.id.empty_view);
+            if (view.getChildCount() > 0) {
+                view.removeAllViews();
+            }
+            if (emptyView != null) {
+                view.addView(emptyView);
+            }
+            view.setVisibility(visible ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    public class NetworkChangeReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (mCallRecordsContainer.getVisibility() != View.VISIBLE) {
+                onRefresh();
+            }
+        }
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordViewHolder.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordViewHolder.java
@@ -1,0 +1,137 @@
+package com.voipgrid.vialer.callrecord;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.preference.PreferenceManager;
+import android.text.format.DateUtils;
+import android.view.View;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import com.github.tamir7.contacts.Contact;
+import com.voipgrid.vialer.R;
+import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.dialer.DialerActivity;
+import com.voipgrid.vialer.util.DialHelper;
+import com.voipgrid.vialer.util.IconHelper;
+import com.voipgrid.vialer.util.TimeUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+import de.hdodenhof.circleimageview.CircleImageView;
+
+public class CallRecordViewHolder extends RecyclerView.ViewHolder  implements View.OnClickListener {
+
+    CircleImageView contactIcon;
+    TextView contactName, contactInformation;
+    ImageButton callButton;
+    CallRecord callRecord;
+
+    private Activity activity;
+    private CachedContacts contacts;
+    private static boolean mCallAlreadySetup = false;
+
+    CallRecordViewHolder(@NonNull View view) {
+        super(view);
+        contactIcon = view.findViewById(R.id.text_view_contact_icon);
+        contactName = view.findViewById(R.id.text_view_contact_name);
+        contactInformation = view.findViewById(R.id.text_view_contact_information);
+        callButton = view.findViewById(R.id.call_record_call_button);
+    }
+
+    public CallRecordViewHolder provideDependencies(Activity activity, CachedContacts contacts) {
+        this.activity = activity;
+        this.contacts = contacts;
+
+        return this;
+    }
+
+    /**
+     * Update this view based on the call record.
+     *
+     * @param callRecord
+     */
+    public void update(CallRecord callRecord) {
+        this.callRecord = callRecord;
+        String number = callRecord.getThirdPartyNumber();
+        Contact contact = contacts.getContact(number);
+        contactIcon.setImageBitmap(getContactImage(number, contact));
+        setNumberAndCallButtonVisibility(callRecord, contact);
+        contactInformation.setCompoundDrawablesWithIntrinsicBounds(getIcon(callRecord), 0, 0, 0);
+        contactInformation.setText(DateUtils.getRelativeDateTimeString(
+                activity,
+                TimeUtils.convertToSystemTime(callRecord.getCallDate()),
+                DateUtils.SECOND_IN_MILLIS,
+                DateUtils.YEAR_IN_MILLIS,
+                DateUtils.FORMAT_ABBREV_TIME
+        ));
+    }
+
+    private void setNumberAndCallButtonVisibility(CallRecord callRecord, @Nullable Contact contact) {
+        if(callRecord.isAnonymous()) {
+            contactName.setText(activity.getString(R.string.supressed_number));
+            callButton.setVisibility(View.GONE);
+            return;
+        }
+
+        callButton.setOnClickListener(this);
+
+        if (contact != null) {
+            contactName.setText(contact.getDisplayName());
+            callButton.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        contactName.setText(callRecord.getThirdPartyNumber());
+        callButton.setVisibility(View.VISIBLE);
+    }
+
+    /**
+     * Attempt to find the contact's image, falling back to a generic icon if
+     * none is available.
+     *
+     * @param number
+     * @param contact
+     * @return
+     */
+    private Bitmap getContactImage(String number, @Nullable Contact contact) {
+        if (contact == null) {
+            return IconHelper.getCallerIconBitmap("", number, 0);
+        }
+
+        Bitmap contactImage = contacts.getContactImage(number);
+
+        if (contactImage != null) {
+            return contactImage;
+        }
+
+        return IconHelper.getCallerIconBitmap(contact.getDisplayName().substring(0, 1), number, 0);
+    }
+
+    /**
+     * Determine the correct call icon to display.
+     *
+     * @param callRecord
+     * @return
+     */
+    private int getIcon(CallRecord callRecord) {
+        if (callRecord.getDirection().equals(CallRecord.DIRECTION_OUTBOUND)) {
+            return R.drawable.ic_outgoing;
+        }
+
+        return callRecord.getDuration() == 0 ? R.drawable.ic_incoming_missed : R.drawable.ic_incoming;
+    }
+
+    @Override
+    public void onClick(View view) {
+        if (callRecord.getThirdPartyNumber() != null && !mCallAlreadySetup) {
+            mCallAlreadySetup = true;
+            DialHelper.fromActivity(activity).callNumber(callRecord.getThirdPartyNumber(), "");
+            PreferenceManager.getDefaultSharedPreferences(activity).edit().putString(
+                    DialerActivity.LAST_DIALED, callRecord.getThirdPartyNumber()).apply();
+        }
+
+        mCallAlreadySetup = false;
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
@@ -39,7 +39,7 @@ public class MissedCalls {
                     public void onResponse(Call<VoipGridResponse<CallRecord>> call,
                             Response<VoipGridResponse<CallRecord>> response) {
                         if (!response.isSuccessful()) {
-                            callback.attemptToRetrieveMissedCallsDidFail();
+                            callback.attemptToRetrieveMissedCallsDidFail(response.code());
                             return;
                         }
 
@@ -48,7 +48,7 @@ public class MissedCalls {
 
                     @Override
                     public void onFailure(Call<VoipGridResponse<CallRecord>> call, Throwable t) {
-                        callback.attemptToRetrieveMissedCallsDidFail();
+                        callback.attemptToRetrieveMissedCallsDidFail(500);
                     }
                 });
     }
@@ -90,6 +90,6 @@ public class MissedCalls {
     public interface Callback {
         void missedCallsHaveBeenRetrieved(List<CallRecord> missedCallRecords);
 
-        void attemptToRetrieveMissedCallsDidFail();
+        void attemptToRetrieveMissedCallsDidFail(int code);
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
@@ -17,7 +17,7 @@ public class MissedCalls {
      * and will look through every record for missed calls.
      *
      */
-    private static final int NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS = 500;
+    private static final int NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS = 500;
 
     private final Api api;
 
@@ -62,9 +62,9 @@ public class MissedCalls {
      */
     private Call<VoipGridResponse<CallRecord>> createHttpCall(boolean fetchCallsFromEntireAccount) {
         if (fetchCallsFromEntireAccount) {
-            return api.getRecentCalls(NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+            return api.getRecentCalls(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
         } else {
-            return api.getRecentCallsForLoggedInUser(NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+            return api.getRecentCallsForLoggedInUser(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
         }
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
@@ -1,0 +1,95 @@
+package com.voipgrid.vialer.callrecord;
+
+import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.api.models.VoipGridResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class MissedCalls {
+
+    /**
+     * This class will make a single request to the api for the number of calls listed here
+     * and will look through every record for missed calls.
+     *
+     */
+    private static final int NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS = 500;
+
+    private final Api api;
+
+    public MissedCalls(Api api) {
+        this.api = api;
+    }
+
+    /**
+     * Fetch the missed calls from the api, missed calls are calculated client side rather than via an
+     * api end-point which means that we have to query a large number of them to find them.
+     *
+     * @param callback To receive a response when the missed calls have been fetched
+     * @param fetchCallsFromEntireAccount The
+     */
+    void fetch(Callback callback, boolean fetchCallsFromEntireAccount) {
+        createHttpCall(fetchCallsFromEntireAccount).enqueue(
+                new retrofit2.Callback<VoipGridResponse<CallRecord>>() {
+                    @Override
+                    public void onResponse(Call<VoipGridResponse<CallRecord>> call,
+                            Response<VoipGridResponse<CallRecord>> response) {
+                        if (!response.isSuccessful()) {
+                            callback.attemptToRetrieveMissedCallsDidFail();
+                            return;
+                        }
+
+                        callback.missedCallsHaveBeenRetrieved(filterMissedCalls(response.body().getObjects()));
+                    }
+
+                    @Override
+                    public void onFailure(Call<VoipGridResponse<CallRecord>> call, Throwable t) {
+                        callback.attemptToRetrieveMissedCallsDidFail();
+                    }
+                });
+    }
+
+    /**
+     * Create the HTTP "Call" object based on whether we should be querying the api for the entire
+     * account or not.
+     *
+     * @param fetchCallsFromEntireAccount If TRUE, all records will be fetched.
+     * @return
+     */
+    private Call<VoipGridResponse<CallRecord>> createHttpCall(boolean fetchCallsFromEntireAccount) {
+        if (fetchCallsFromEntireAccount) {
+            return api.getRecentCalls(NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+        } else {
+            return api.getRecentCallsForLoggedInUser(NUMBER_OF_RECORDS_TO__PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+        }
+    }
+
+    /**
+     * Work through the list of CallRecords and determine which are missed
+     * and which are not.
+     *
+     * @param records
+     * @return
+     */
+    private List<CallRecord> filterMissedCalls(List<CallRecord> records) {
+        List<CallRecord> missedCalls = new ArrayList<>();
+
+        for (CallRecord record : records) {
+            if (record.wasMissed()) {
+                missedCalls.add(record);
+            }
+        }
+
+        return missedCalls;
+    }
+
+    public interface Callback {
+        void missedCallsHaveBeenRetrieved(List<CallRecord> missedCallRecords);
+
+        void attemptToRetrieveMissedCallsDidFail();
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCallsAdapter.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCallsAdapter.java
@@ -1,0 +1,62 @@
+package com.voipgrid.vialer.callrecord;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.voipgrid.vialer.R;
+import com.voipgrid.vialer.api.models.CallRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class MissedCallsAdapter extends RecyclerView.Adapter<CallRecordViewHolder> {
+
+    private Activity activity;
+    private final CachedContacts contacts;
+
+    private List<CallRecord> records = new ArrayList<>();
+
+    public MissedCallsAdapter(CachedContacts contacts) {
+        this.contacts = contacts;
+    }
+
+    @NonNull
+    @Override
+    public CallRecordViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_call_record, parent, false);
+
+        return new CallRecordViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CallRecordViewHolder holder, int position) {
+        CallRecord callRecord = records.get(position);
+
+        if (callRecord == null) return;
+
+        holder.provideDependencies(activity, contacts);
+        holder.update(callRecord);
+    }
+
+    @Override
+    public int getItemCount() {
+        return records.size();
+    }
+
+    public void setRecords(List<CallRecord> objects) {
+        this.records = objects;
+        notifyDataSetChanged();
+    }
+
+    public MissedCallsAdapter setActivity(Activity activity) {
+        this.activity = activity;
+
+        return this;
+    }
+}

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
@@ -8,6 +8,7 @@ import com.voipgrid.vialer.calling.IncomingCallActivity;
 import com.voipgrid.vialer.calling.NetworkAvailabilityActivity;
 import com.voipgrid.vialer.calling.PendingCallActivity;
 import com.voipgrid.vialer.callrecord.CallRecordAdapter;
+import com.voipgrid.vialer.callrecord.CallRecordFragment;
 import com.voipgrid.vialer.dialer.DialerActivity;
 import com.voipgrid.vialer.sip.CodecPriorityMap;
 import com.voipgrid.vialer.sip.NetworkConnectivity;
@@ -41,4 +42,6 @@ public interface VialerComponent {
     void inject(NetworkConnectivity networkConnectivity);
 
     Preferences getPreferences();
+
+    void inject(CallRecordFragment fragment);
 }

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
@@ -4,7 +4,9 @@ import com.voipgrid.vialer.CallActivity;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.api.models.InternalNumbers;
 import com.voipgrid.vialer.api.models.PhoneAccount;
+import com.voipgrid.vialer.api.models.UserDestination;
 import com.voipgrid.vialer.calling.AbstractCallActivity;
 import com.voipgrid.vialer.calling.IncomingCallActivity;
 import com.voipgrid.vialer.calling.NetworkAvailabilityActivity;
@@ -51,5 +53,5 @@ public interface VialerComponent {
     void inject(CallRecord callRecord);
 
     @Nullable
-    PhoneAccount getPhoneAccount();
+    InternalNumbers getInternalNumbers();
 }

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerComponent.java
@@ -3,6 +3,8 @@ package com.voipgrid.vialer.dagger;
 import com.voipgrid.vialer.CallActivity;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.VialerApplication;
+import com.voipgrid.vialer.api.models.CallRecord;
+import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.calling.AbstractCallActivity;
 import com.voipgrid.vialer.calling.IncomingCallActivity;
 import com.voipgrid.vialer.calling.NetworkAvailabilityActivity;
@@ -16,6 +18,7 @@ import com.voipgrid.vialer.sip.SipService;
 
 import javax.inject.Singleton;
 
+import androidx.annotation.Nullable;
 import dagger.Component;
 
 @Singleton
@@ -44,4 +47,9 @@ public interface VialerComponent {
     Preferences getPreferences();
 
     void inject(CallRecordFragment fragment);
+
+    void inject(CallRecord callRecord);
+
+    @Nullable
+    PhoneAccount getPhoneAccount();
 }

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
@@ -7,16 +7,26 @@ import android.net.ConnectivityManager;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telephony.TelephonyManager;
 
+import com.github.tamir7.contacts.Contact;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
+import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.ServiceGenerator;
+import com.voipgrid.vialer.api.models.InternalNumbers;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SystemUser;
+import com.voipgrid.vialer.api.models.UserDestination;
 import com.voipgrid.vialer.calling.CallActivityHelper;
 import com.voipgrid.vialer.calling.CallNotifications;
+import com.voipgrid.vialer.callrecord.CachedContacts;
+import com.voipgrid.vialer.callrecord.CallRecordAdapter;
+import com.voipgrid.vialer.callrecord.CallRecordDataSource;
+import com.voipgrid.vialer.callrecord.CallRecordDataSourceFactory;
 import com.voipgrid.vialer.contacts.Contacts;
 import com.voipgrid.vialer.reachability.ReachabilityReceiver;
 import com.voipgrid.vialer.sip.IpSwitchMonitor;
@@ -76,6 +86,16 @@ public class VialerModule {
     @Provides @Nullable
     PhoneAccount providePhoneAccount(JsonStorage jsonStorage) {
         return (PhoneAccount) jsonStorage.get(PhoneAccount.class);
+    }
+
+    @Provides @Nullable
+    UserDestination provideUserDestination(JsonStorage jsonStorage) {
+        return (UserDestination) jsonStorage.get(UserDestination.class);
+    }
+
+    @Provides @Nullable
+    InternalNumbers provideInternalNumbers(JsonStorage jsonStorage) {
+        return (InternalNumbers) jsonStorage.get(InternalNumbers.class);
     }
 
     @Provides
@@ -147,4 +167,24 @@ public class VialerModule {
     NetworkUtil provideNetworkUtil(Context context) {
         return new NetworkUtil(context);
     }
+
+    @Provides
+    Api provideApi(Context context) {
+        return ServiceGenerator.createApiService(context);
+    }
+
+    @Provides
+    CallRecordDataSourceFactory provideCallRecordDataSourceFactory(Api api) {
+        return new CallRecordDataSourceFactory(api);
+    }
+
+    @Provides
+    CallRecordAdapter provideCallRecordAdapter(Context context, CachedContacts cachedContacts) {
+        return new CallRecordAdapter(context, cachedContacts);
+    }
+
+    @Provides CachedContacts provideCachedContacts(Contacts contacts) {
+        return new CachedContacts(contacts);
+    }
+
 }

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.preference.PreferenceManager;
+
+import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telephony.TelephonyManager;
 
@@ -71,7 +73,7 @@ public class VialerModule {
         return (SystemUser) jsonStorage.get(SystemUser.class);
     }
 
-    @Provides
+    @Provides @Nullable
     PhoneAccount providePhoneAccount(JsonStorage jsonStorage) {
         return (PhoneAccount) jsonStorage.get(PhoneAccount.class);
     }

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
@@ -27,6 +27,8 @@ import com.voipgrid.vialer.callrecord.CachedContacts;
 import com.voipgrid.vialer.callrecord.CallRecordAdapter;
 import com.voipgrid.vialer.callrecord.CallRecordDataSource;
 import com.voipgrid.vialer.callrecord.CallRecordDataSourceFactory;
+import com.voipgrid.vialer.callrecord.MissedCalls;
+import com.voipgrid.vialer.callrecord.MissedCallsAdapter;
 import com.voipgrid.vialer.contacts.Contacts;
 import com.voipgrid.vialer.reachability.ReachabilityReceiver;
 import com.voipgrid.vialer.sip.IpSwitchMonitor;
@@ -179,12 +181,20 @@ public class VialerModule {
     }
 
     @Provides
-    CallRecordAdapter provideCallRecordAdapter(Context context, CachedContacts cachedContacts) {
-        return new CallRecordAdapter(context, cachedContacts);
+    CallRecordAdapter provideCallRecordAdapter(CachedContacts cachedContacts) {
+        return new CallRecordAdapter(cachedContacts);
     }
 
     @Provides CachedContacts provideCachedContacts(Contacts contacts) {
         return new CachedContacts(contacts);
     }
 
+    @Provides
+    MissedCalls provideMissedCalls(Api api) {
+        return new MissedCalls(api);
+    }
+
+    @Provides MissedCallsAdapter provideMissedCallsAdapter(CachedContacts cachedContacts) {
+        return new MissedCallsAdapter(cachedContacts);
+    }
 }

--- a/app/src/main/java/com/voipgrid/vialer/onboarding/SetupActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/onboarding/SetupActivity.java
@@ -329,7 +329,7 @@ public class SetupActivity extends RemoteLoggingActivity implements
                     });
                 } else {
                     if (systemUser.getOutgoingCli() == null || systemUser.getOutgoingCli().isEmpty()) {
-                        mLogger.d("onResponse getOutgoingCli is null");
+                        mLogger.d("missedCallsHaveBeenRetrieved getOutgoingCli is null");
                     }
                     mPreferences.setSipPermission(true);
 

--- a/app/src/main/java/com/voipgrid/vialer/permissions/MicrophonePermission.java
+++ b/app/src/main/java/com/voipgrid/vialer/permissions/MicrophonePermission.java
@@ -31,11 +31,11 @@ public class MicrophonePermission {
     /**
      * Function to check if the we have the microphone permission.
      *
-     * @param context Context needed for the check.
+     * @param activity Context needed for the check.
      * @return Whether or not we have permission.
      */
-    public static boolean hasPermission(Context context) {
-        return getPermissionStatus((Activity) context, mPermissionToCheck) == GRANTED;
+    public static boolean hasPermission(Activity activity) {
+        return getPermissionStatus(activity, mPermissionToCheck) == GRANTED;
     }
 
     private static int getPermissionStatus(Activity activity, String androidPermissionName) {

--- a/app/src/main/java/com/voipgrid/vialer/util/DialHelper.java
+++ b/app/src/main/java/com/voipgrid/vialer/util/DialHelper.java
@@ -7,10 +7,13 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Handler;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+
 import android.widget.Toast;
 
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
+import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
 import com.voipgrid.vialer.api.models.PhoneAccount;
@@ -49,7 +52,7 @@ public class DialHelper {
     public static DialHelper fromActivity (Activity activity) {
         JsonStorage jsonStorage = new JsonStorage(activity);
         ConnectivityHelper connectivityHelper = ConnectivityHelper.get(activity);
-        AnalyticsHelper analyticsHelper = new AnalyticsHelper(((AnalyticsApplication) activity.getApplication()).getDefaultTracker());
+        AnalyticsHelper analyticsHelper = new AnalyticsHelper(VialerApplication.get().getDefaultTracker());
 
         return new DialHelper(activity, jsonStorage, connectivityHelper, analyticsHelper);
     }
@@ -117,7 +120,7 @@ public class DialHelper {
                     && mJsonStorage.has(PhoneAccount.class)
                     && mConnectivityHelper.hasFastData()) {
                 // Check if we have permission to use the microphone. If not, request it.
-                if (!MicrophonePermission.hasPermission(mContext)) {
+                if (!MicrophonePermission.hasPermission((Activity) mContext)) {
                     sNumberAttemptedToCall = number;
                     MicrophonePermission.askForPermission((Activity) mContext);
                     return;

--- a/app/src/main/java/com/voipgrid/vialer/util/TimeUtils.java
+++ b/app/src/main/java/com/voipgrid/vialer/util/TimeUtils.java
@@ -1,0 +1,30 @@
+package com.voipgrid.vialer.util;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.TimeZone;
+
+public class TimeUtils {
+
+    /**
+     * Convert milliseconds to system time, assuming the time has been provided in europe time (UTC+1).
+     *
+     * @param datetime The timestamp to convert
+     */
+    public static long convertToSystemTime(String datetime) {
+        return convertToSystemTime(datetime, "Europe/Amsterdam");
+    }
+
+    /**
+     * Convert the provided milliseconds to the system timezone.
+     *
+     * @param datetime The timestamp to convert
+     * @param initialTimezone The timezone that the timestamp has been provided in
+     */
+    public static long convertToSystemTime(String datetime, String initialTimezone) {
+        return new DateTime(datetime, DateTimeZone.forID(initialTimezone))
+                .withZone(DateTimeZone.forID(TimeZone.getDefault().getID()))
+                .getMillis();
+    }
+}

--- a/app/src/main/res/layout/fragment_call_records.xml
+++ b/app/src/main/res/layout/fragment_call_records.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/call_records_background">
 
     <LinearLayout
         android:id="@+id/empty_view"
@@ -17,6 +18,31 @@
         android:layout_height="match_parent"
         android:orientation="vertical"
         >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="@color/call_records_item_background"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="10dp">
+
+            <Switch
+                android:id="@+id/show_calls_for_whole_client_switch"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingRight="@dimen/list_item_contact_padding_right"
+                android:paddingLeft="@dimen/list_item_contact_padding_left"
+                android:paddingTop="15dp"
+                android:paddingBottom="15dp"
+                android:text="@string/call_records_show_all"
+                android:textSize="@dimen/contact_name_text_size"
+                android:fontFamily="sans-serif"
+                android:textColor="@color/contact_name_text_color"
+            />
+
+        </LinearLayout>
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipe_container"

--- a/app/src/main/res/layout/fragment_call_records.xml
+++ b/app/src/main/res/layout/fragment_call_records.xml
@@ -10,13 +10,13 @@
         android:layout_height="match_parent"
         android:orientation="vertical"
         android:gravity="center_horizontal">
-
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
+        android:id="@+id/call_records_container"
         >
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_call_records.xml
+++ b/app/src/main/res/layout/fragment_call_records.xml
@@ -28,7 +28,7 @@
             android:layout_marginTop="10dp">
 
             <Switch
-                android:id="@+id/show_calls_for_whole_client_switch"
+                android:id="@+id/show_missed_calls_only_switch"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
@@ -50,8 +50,8 @@
             android:layout_height="match_parent"
             >
 
-            <ListView
-                android:id="@android:id/list"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/call_records"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:paddingBottom="90dp"

--- a/app/src/main/res/layout/list_item_call_record.xml
+++ b/app/src/main/res/layout/list_item_call_record.xml
@@ -6,7 +6,8 @@
     android:paddingRight="@dimen/list_item_contact_padding_right"
     android:paddingLeft="@dimen/list_item_contact_padding_left"
     android:paddingTop="@dimen/list_item_contact_padding_top"
-    android:paddingBottom="@dimen/list_item_contact_padding_bottom">
+    android:paddingBottom="@dimen/list_item_contact_padding_bottom"
+    android:background="@color/call_records_item_background">
 
     <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/text_view_contact_icon"

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -252,4 +252,7 @@
     <string name="choose_codec_text">Audio Kwaliteit</string>
     <string name="call_codec_standard_quality">Standaard audio</string>
     <string name="call_codec_high_quality">Hogere audio kwaliteit</string>
+    <string name="tab_title_recents">mijn gesprekken</string>
+    <string name="tab_title_missed">alle gesprekken</string>
+    <string name="call_records_show_all">Laat alleen gemiste gesprekken zien</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -148,8 +148,6 @@
     <string name="account_availability_switch_title">Bereikbaarheid</string>
     <string name="add_availability">Bereikbaarheid toevoegen</string>
     <string name="not_available">Niet bereikbaar</string>
-    <string name="tab_title_recents">recent</string>
-    <string name="tab_title_missed">gemist</string>
 
     <!-- Call notification values -->
     <string name="callnotification_incoming_call">Inkomend gesprek</string>

--- a/app/src/main/res/values/common_colors.xml
+++ b/app/src/main/res/values/common_colors.xml
@@ -45,4 +45,7 @@
     <color name="drawer_header_text_color_email">#B3FFFFFF</color>
 
     <color name="call_transfer_color">@color/call_fab_pickup_color</color>
+
+    <color name="call_records_background">#E9E9E9</color>
+    <color name="call_records_item_background">#fff</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,7 +160,7 @@
     <string name="add_availability">Add availability</string>
     <string name="not_available">Not available</string>
     <string name="tab_title_recents">my calls</string>
-    <string name="tab_title_missed">all</string>
+    <string name="tab_title_missed">all calls</string>
 
     <string name="navigation_name_placeholder_text">No outgoing number configured</string>
     <string name="supressed_number">Anonymous</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,8 +159,8 @@
     <string name="account_availability_switch_title">Availability</string>
     <string name="add_availability">Add availability</string>
     <string name="not_available">Not available</string>
-    <string name="tab_title_recents">all</string>
-    <string name="tab_title_missed">missed</string>
+    <string name="tab_title_recents">my calls</string>
+    <string name="tab_title_missed">all</string>
 
     <string name="navigation_name_placeholder_text">No outgoing number configured</string>
     <string name="supressed_number">Anonymous</string>
@@ -256,5 +256,5 @@
     <string name="choose_codec_text">Audio Quality</string>
     <string name="call_codec_standard_quality">Standard audio</string>
     <string name="call_codec_high_quality">Higher quality audio</string>
-    <string name="call_records_show_all">Show calls belonging to other users</string>
+    <string name="call_records_show_all">Show missed calls only</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="two_factor_authentication_header_label_subtext">Authentication</string>
 
     <!-- strings empty view call records -->
-    <string name="empty_view_default_message">No recent calls available (yet).</string>
+    <string name="empty_view_default_message">No recent calls available.</string>
     <string name="empty_view_missed_message">No missed calls.</string>
     <string name="empty_view_unauthorized_message">You are not allowed to see call records.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,7 @@
     <string name="account_availability_switch_title">Availability</string>
     <string name="add_availability">Add availability</string>
     <string name="not_available">Not available</string>
-    <string name="tab_title_recents">recent</string>
+    <string name="tab_title_recents">all</string>
     <string name="tab_title_missed">missed</string>
 
     <string name="navigation_name_placeholder_text">No outgoing number configured</string>
@@ -256,4 +256,5 @@
     <string name="choose_codec_text">Audio Quality</string>
     <string name="call_codec_standard_quality">Standard audio</string>
     <string name="call_codec_high_quality">Higher quality audio</string>
+    <string name="call_records_show_all">Show calls belonging to other users</string>
 </resources>


### PR DESCRIPTION
This branch has made significant changes to the call records:

- Changed the main tabs to "My Calls" and "All Calls", with a toggle to view missed calls.
- Replaced the outdated method of displaying call records with RecyclerView and ViewHolder pattern.
- Implemented infinite scrolling, so it is possible to view an entire month's worth of calls rather than the hard-coded 50 previously.
- Fixed an issue where the time displayed on call records would not respect the user's system timezone.
- Removed caching from call records so without an internet connection it will no longer show outdated (therefore incorrect) information. However the call records should
automatically refresh when the internet connection is restored.
- Improved detection from what counts as an incoming/outgoing call, no longer just uses the direction provided by the api but will look at the current user's numbers
to determine the direction. This also fixes the issue of missed calls not working for internal calls.
- Missed calls are now discovered by querying the api for the most recent 500 calls, and filtering on them, this should make it more accurate (although it's still not a perfect system).
- Added an okhttp interceptor so all http requests are logged to the console automatically.