### PR TITLE
VIALA-973: Incoming calls failing on Samsung S9

### DIFF
--- a/app/src/annabel/res/xml/tracker.xml
+++ b/app/src/annabel/res/xml/tracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
 
     <string name="ga_trackingId">UA-118894560-1</string>
 
@@ -13,7 +13,7 @@
     <screenName name="com.voipgrid.vialer.onboarding.SetupActivity">
         Onboarding
     </screenName>
-    <screenName name="com.voipgrid.vialer.AccountActivity">
+    <screenName name="com.voipgrid.vialer.SettingsActivity">
         Settings
     </screenName>
     <screenName name="com.voipgrid.vialer.CallActivity">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
             android:name=".dialer.DialerActivity"
             android:label="@string/title_activity_dialer"
             android:screenOrientation="portrait" >
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -217,7 +217,7 @@
         <service android:name=".contacts.UpdateChangedContactsService" />
 
         <activity
-            android:name=".AccountActivity"
+            android:name=".SettingsActivity"
             android:label="@string/title_activity_account"
             android:parentActivityName=".MainActivity"
             android:screenOrientation="portrait" >

--- a/app/src/main/java/com/voipgrid/vialer/CallActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/CallActivity.java
@@ -391,7 +391,8 @@ public class CallActivity extends AbstractCallActivity implements
             mSipServiceConnection.get().getCurrentCall().hangup(true);
             updateUi();
         } catch (Exception e) {
-            e.printStackTrace();
+            finish();
+            return;
         }
 
         finishAfterDelay();

--- a/app/src/main/java/com/voipgrid/vialer/NavigationDrawerActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/NavigationDrawerActivity.java
@@ -20,7 +20,6 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.Toolbar;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -30,7 +29,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.Destination;
 import com.voipgrid.vialer.api.models.FixedDestination;
@@ -46,8 +45,6 @@ import com.voipgrid.vialer.util.JsonStorage;
 import com.voipgrid.vialer.util.LoginRequiredActivity;
 import com.voipgrid.vialer.middleware.MiddlewareHelper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import retrofit2.Call;
@@ -68,7 +65,7 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
     private TextView mNoConnectionText;
     private View mNavigationHeaderView;
 
-    private Api mApi;
+    private VoipgridApi mVoipgridApi;
     private ConnectivityHelper mConnectivityHelper;
     private JsonStorage mJsonStorage;
     private SystemUser mSystemUser;
@@ -165,8 +162,8 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
             return;
         }
 
-        mApi = ServiceGenerator.createApiService(this);
-        Call<VoipGridResponse<UserDestination>> call = mApi.getUserDestination();
+        mVoipgridApi = ServiceGenerator.createApiService(this);
+        Call<VoipGridResponse<UserDestination>> call = mVoipgridApi.getUserDestination();
         call.enqueue(this);
     }
 
@@ -236,7 +233,7 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
                 );
                 break;
             case R.id.navigation_item_settings:
-                startActivity(new Intent(this, AccountActivity.class));
+                startActivity(new Intent(this, SettingsActivity.class));
                 break;
             case R.id.navigation_item_logout:
                 logout();
@@ -461,7 +458,7 @@ public abstract class NavigationDrawerActivity extends LoginRequiredActivity
                 SelectedUserDestinationParams params = new SelectedUserDestinationParams();
                 params.fixedDestination = destination instanceof FixedDestination ? destination.getId() : null;
                 params.phoneAccount = destination instanceof PhoneAccount ? destination.getId() : null;
-                Call<Object> call = mApi.setSelectedUserDestination(mSelectedUserDestinationId, params);
+                Call<Object> call = mVoipgridApi.setSelectedUserDestination(mSelectedUserDestinationId, params);
                 call.enqueue(this);
                 if (!MiddlewareHelper.isRegistered(this)) {
                     // If the previous destination was not available, or if we're not registered

--- a/app/src/main/java/com/voipgrid/vialer/SettingsActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/SettingsActivity.java
@@ -23,7 +23,7 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.Toast;
 
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.SecureCalling;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.MobileNumber;
@@ -51,7 +51,7 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-public class AccountActivity extends LoginRequiredActivity {
+public class SettingsActivity extends LoginRequiredActivity {
 
     @BindView(R.id.container) View mContainer;
     @BindView(R.id.progressBar) ProgressBar mProgressBar;
@@ -81,7 +81,7 @@ public class AccountActivity extends LoginRequiredActivity {
     private Preferences mPreferences;
     private JsonStorage mJsonStorage;
     private SystemUser mSystemUser;
-    private Api mApi;
+    private VoipgridApi mVoipgridApi;
     private Logger mLogger;
     private ClipboardHelper mClipboardHelper;
     private BroadcastReceiverManager mBroadcastReceiverManager;
@@ -98,13 +98,13 @@ public class AccountActivity extends LoginRequiredActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_account);
+        setContentView(R.layout.activity_settings);
         ButterKnife.bind(this);
 
         mJsonStorage = new JsonStorage(this);
         mPhoneAccountHelper = new PhoneAccountHelper(this);
         mPreferences = new Preferences(this);
-        mApi = ServiceGenerator.createApiService(this);
+        mVoipgridApi = ServiceGenerator.createApiService(this);
         mLogger = new Logger(this.getClass());
         mClipboardHelper =  ClipboardHelper.fromContext(this);
         mBroadcastReceiverManager = BroadcastReceiverManager.fromContext(this);
@@ -187,7 +187,7 @@ public class AccountActivity extends LoginRequiredActivity {
         });
         mRemoteLogIdEditText.setOnLongClickListener(view -> {
             mClipboardHelper.copyToClipboard(mRemoteLogIdEditText.getText().toString());
-            Toast.makeText(AccountActivity.this,R.string.remote_logging_id_copied , Toast.LENGTH_SHORT).show();
+            Toast.makeText(SettingsActivity.this,R.string.remote_logging_id_copied , Toast.LENGTH_SHORT).show();
             return true;
         });
         if (mPreferences.remoteLoggingIsActive()) {
@@ -233,10 +233,10 @@ public class AccountActivity extends LoginRequiredActivity {
                         // to disabled. Setting disabled in the settings first makes sure
                         // the onCheckChanged does not execute the code that normally is executed
                         // on a change in the check of the switch.
-                        SetupActivity.launchToSetVoIPAccount(AccountActivity.this);
+                        SetupActivity.launchToSetVoIPAccount(SettingsActivity.this);
                     }
 
-                    NotificationHelper.getInstance(AccountActivity.this).removeVoipDisabledNotification();
+                    NotificationHelper.getInstance(SettingsActivity.this).removeVoipDisabledNotification();
                 }
             }.execute();
         }
@@ -259,6 +259,7 @@ public class AccountActivity extends LoginRequiredActivity {
     @OnItemSelected(R.id.codec_spinner)
     public void onCodecSelected(AdapterView<?> parent, View view, int pos, long id) {
         mPreferences.setAudioCodec(pos + 1);
+        SecureCalling.fromContext(this).updateApiBasedOnCurrentPreferenceSetting();
     }
 
     @OnCheckedChanged(R.id.remote_logging_switch)
@@ -401,7 +402,7 @@ public class AccountActivity extends LoginRequiredActivity {
 
         String number = PhoneNumberUtils.formatMobileNumber(mMobileNumberEditText.getText().toString());
 
-        mApi
+        mVoipgridApi
                 .mobileNumber(new MobileNumber(number))
                 .enqueue(new MobileNumberUpdatedCallback(number));
 
@@ -495,7 +496,7 @@ public class AccountActivity extends LoginRequiredActivity {
             enableProgressBar(false);
 
             DialogHelper.displayAlert(
-                    AccountActivity.this,
+                    SettingsActivity.this,
                     getString(R.string.onboarding_account_configure_failed_title),
                     getString(R.string.onboarding_account_configure_invalid_phone_number)
             );

--- a/app/src/main/java/com/voipgrid/vialer/WebActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/WebActivity.java
@@ -16,7 +16,7 @@ import android.widget.Toast;
 
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.AutoLoginToken;
 import com.voipgrid.vialer.util.AccountHelper;
@@ -144,13 +144,13 @@ public class WebActivity extends LoginRequiredActivity implements Callback<AutoL
      */
     private void autoLoginToken() {
         mProgressBar.setVisibility(View.VISIBLE);
-        Api api = ServiceGenerator.createApiService(
+        VoipgridApi voipgridApi = ServiceGenerator.createApiService(
                 this,
                 getIntent().getStringExtra(USERNAME),
                 getIntent().getStringExtra(PASSWORD),
                 getIntent().getStringExtra(API_TOKEN)
         );
-        Call<AutoLoginToken> call = api.autoLoginToken();
+        Call<AutoLoginToken> call = voipgridApi.autoLoginToken();
         call.enqueue(this);
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/api/ApiTokenFetcher.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/ApiTokenFetcher.java
@@ -17,16 +17,16 @@ public class ApiTokenFetcher {
 
     private final String mUsername;
     private final String mPassword;
-    private final Api mApi;
+    private final VoipgridApi mVoipgridApi;
     private final AccountHelper mAccountHelper;
     private final Logger mLogger;
 
     private ApiTokenListener mListener;
 
-    private ApiTokenFetcher(String username, String password, Api api, AccountHelper accountHelper, Logger logger) {
+    private ApiTokenFetcher(String username, String password, VoipgridApi voipgridApi, AccountHelper accountHelper, Logger logger) {
         mUsername = username;
         mPassword = password;
-        mApi = api;
+        mVoipgridApi = voipgridApi;
         mAccountHelper = accountHelper;
         mLogger = logger;
     }
@@ -106,7 +106,7 @@ public class ApiTokenFetcher {
      * @param responseHandler
      */
     private void enqueue(ApiTokenRequest request, ApiTokenHttpResponseHandler responseHandler) {
-        mApi
+        mVoipgridApi
                 .apiToken(request)
                 .enqueue(responseHandler);
     }

--- a/app/src/main/java/com/voipgrid/vialer/api/Middleware.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/Middleware.java
@@ -15,7 +15,7 @@ import retrofit2.http.POST;
  *
  * API calls for registration on the VoipGrid middleware
  */
-public interface Registration {
+public interface Middleware {
 
 
     @FormUrlEncoded

--- a/app/src/main/java/com/voipgrid/vialer/api/ServiceGenerator.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/ServiceGenerator.java
@@ -57,20 +57,20 @@ public class ServiceGenerator {
         return httpClient.build();
     }
 
-    public static Api createApiService(Context context) {
+    public static VoipgridApi createApiService(Context context) {
         AccountHelper accountHelper = new AccountHelper(context);
         return createApiService(context, accountHelper.getEmail(), accountHelper.getPassword(), accountHelper.getApiToken());
     }
 
-    public static Api createApiService(Context context, @Nullable String username, @Nullable String password, @Nullable String token) {
-        return ServiceGenerator.createService(context, Api.class, username, password, token, getVgApiUrl(context));
+    public static VoipgridApi createApiService(Context context, @Nullable String username, @Nullable String password, @Nullable String token) {
+        return ServiceGenerator.createService(context, VoipgridApi.class, username, password, token, getVgApiUrl(context));
     }
 
-    public static Registration createRegistrationService(Context context, @Nullable String username, @Nullable String password, @Nullable String token) {
-        return ServiceGenerator.createService(context, Registration.class, username, password, token, getRegistrationUrl(context));
+    public static Middleware createRegistrationService(Context context, @Nullable String username, @Nullable String password, @Nullable String token) {
+        return ServiceGenerator.createService(context, Middleware.class, username, password, token, getRegistrationUrl(context));
     }
 
-    public static Registration createRegistrationService(Context context) {
+    public static Middleware createRegistrationService(Context context) {
         AccountHelper accountHelper = new AccountHelper(context);
         return createRegistrationService(context, accountHelper.getEmail(), accountHelper.getPassword(), accountHelper.getApiToken());
     }

--- a/app/src/main/java/com/voipgrid/vialer/api/VoipgridApi.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/VoipgridApi.java
@@ -9,7 +9,7 @@ import com.voipgrid.vialer.api.models.MobileNumber;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SelectedUserDestinationParams;
 import com.voipgrid.vialer.api.models.SystemUser;
-import com.voipgrid.vialer.api.models.UseEncryption;
+import com.voipgrid.vialer.api.models.UpdateVoIPAccountParameters;
 import com.voipgrid.vialer.api.models.UserDestination;
 import com.voipgrid.vialer.api.models.VoipGridResponse;
 import com.voipgrid.vialer.models.ClickToDialParams;
@@ -27,7 +27,7 @@ import retrofit2.http.Query;
 /**
  * API interface
  */
-public interface Api {
+public interface VoipgridApi {
 
     @GET("api/autologin/token/")
     Call<AutoLoginToken> autoLoginToken();
@@ -54,7 +54,7 @@ public interface Api {
     Call<MobileNumber> mobileNumber(@Body MobileNumber mobileNumber);
 
     @PUT("api/mobile/profile/")
-    Call<UseEncryption> useEncryption(@Body UseEncryption useEncryption);
+    Call<UpdateVoIPAccountParameters> updateVoipAccount(@Body UpdateVoIPAccountParameters updateVoIPAccountParameters);
 
     @POST("api/permission/password_reset/")
     Call<Void> resetPassword(@Body PasswordResetParams params);

--- a/app/src/main/java/com/voipgrid/vialer/api/models/UpdateVoIPAccountParameters.java
+++ b/app/src/main/java/com/voipgrid/vialer/api/models/UpdateVoIPAccountParameters.java
@@ -2,12 +2,15 @@ package com.voipgrid.vialer.api.models;
 
 import com.google.gson.annotations.SerializedName;
 
-public class UseEncryption {
+public class UpdateVoIPAccountParameters {
 
     @SerializedName("appaccount_use_encryption")
     private Boolean useEncryption;
 
-    public UseEncryption(Boolean useEncryption) {
+    @SerializedName("appaccount_use_opus")
+    private Boolean useOpus = true;
+
+    public UpdateVoIPAccountParameters(Boolean useEncryption) {
         this.useEncryption = useEncryption;
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/calling/CallDurationTracker.java
+++ b/app/src/main/java/com/voipgrid/vialer/calling/CallDurationTracker.java
@@ -37,7 +37,14 @@ public class CallDurationTracker implements Runnable {
         }
 
         if (hasActiveCalls(mSipServiceConnection)) {
-            mListener.onCallDurationUpdate(findCallDuration());
+            long duration = findCallDuration();
+
+            if (duration < 0) {
+                stop();
+                return;
+            }
+
+            mListener.onCallDurationUpdate(duration);
         }
 
         sHandler.postDelayed(this, INTERVAL_MS);

--- a/app/src/main/java/com/voipgrid/vialer/calling/IncomingCallActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/calling/IncomingCallActivity.java
@@ -10,6 +10,7 @@ import android.app.KeyguardManager;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -76,7 +77,9 @@ public class IncomingCallActivity extends AbstractCallActivity {
         try {
             mSipServiceConnection.get().getCurrentCall().decline();
         } catch (Exception e) {
-            e.printStackTrace();
+            mLogger.e("Unable to decline call with error: " + e.getMessage());
+            finish();
+            return;
         }
 
         mCallNotifications.removeAll();
@@ -96,7 +99,8 @@ public class IncomingCallActivity extends AbstractCallActivity {
         try {
             mSipServiceConnection.get().getCurrentCall().answer();
         } catch (Exception e) {
-            e.printStackTrace();
+            mLogger.e("Unable to answer phone with error: " + e.getMessage());
+            finish();
         }
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSource.java
@@ -1,8 +1,6 @@
 package com.voipgrid.vialer.callrecord;
 
-import android.util.Log;
-
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.models.CallRecord;
 import com.voipgrid.vialer.api.models.VoipGridResponse;
 
@@ -17,12 +15,12 @@ import retrofit2.Response;
 
 public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
 
-    private final Api api;
+    private final VoipgridApi mVoipgridApi;
 
     private int code;
 
-    CallRecordDataSource(Api api) {
-        this.api = api;
+    CallRecordDataSource(VoipgridApi voipgridApi) {
+        this.mVoipgridApi = voipgridApi;
     }
 
     /**
@@ -75,9 +73,9 @@ public class CallRecordDataSource extends PositionalDataSource<CallRecord> {
             Response<VoipGridResponse<CallRecord>> call;
 
             if (fetchCallsFromEntireAccount) {
-                call = api.getRecentCalls(size, startPosition, CallRecord.getLimitDate()).execute();
+                call = mVoipgridApi.getRecentCalls(size, startPosition, CallRecord.getLimitDate()).execute();
             } else {
-                call = api.getRecentCallsForLoggedInUser(size, startPosition, CallRecord.getLimitDate()).execute();
+                call = mVoipgridApi.getRecentCallsForLoggedInUser(size, startPosition, CallRecord.getLimitDate()).execute();
             }
 
             code = call.code();

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSourceFactory.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/CallRecordDataSourceFactory.java
@@ -1,6 +1,6 @@
 package com.voipgrid.vialer.callrecord;
 
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.models.CallRecord;
 
 import androidx.lifecycle.MutableLiveData;
@@ -8,18 +8,18 @@ import androidx.paging.DataSource;
 
 public class CallRecordDataSourceFactory extends DataSource.Factory<Integer, CallRecord> {
 
-    private final Api api;
+    private final VoipgridApi mVoipgridApi;
     private MutableLiveData<CallRecordDataSource> postLiveData;
 
     private boolean fetchCallsFromEntireAccount = false;
 
-    public CallRecordDataSourceFactory(Api api) {
-        this.api = api;
+    public CallRecordDataSourceFactory(VoipgridApi voipgridApi) {
+        this.mVoipgridApi = voipgridApi;
     }
 
     @Override
     public DataSource<Integer, CallRecord> create() {
-        CallRecordDataSource dataSource = new CallRecordDataSource(api);
+        CallRecordDataSource dataSource = new CallRecordDataSource(mVoipgridApi);
         if (fetchCallsFromEntireAccount) {
             dataSource.fetchCallsFromEntireAccount();
         }
@@ -28,13 +28,13 @@ public class CallRecordDataSourceFactory extends DataSource.Factory<Integer, Cal
         return dataSource;
     }
 
-    public CallRecordDataSourceFactory fetchCallsFromEntireAccount() {
+    CallRecordDataSourceFactory fetchCallsFromEntireAccount() {
         fetchCallsFromEntireAccount = true;
 
         return this;
     }
 
-    public MutableLiveData<CallRecordDataSource> getPostLiveData() {
+    MutableLiveData<CallRecordDataSource> getPostLiveData() {
         return postLiveData;
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
+++ b/app/src/main/java/com/voipgrid/vialer/callrecord/MissedCalls.java
@@ -1,6 +1,6 @@
 package com.voipgrid.vialer.callrecord;
 
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.models.CallRecord;
 import com.voipgrid.vialer.api.models.VoipGridResponse;
 
@@ -19,10 +19,10 @@ public class MissedCalls {
      */
     private static final int NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS = 500;
 
-    private final Api api;
+    private final VoipgridApi mVoipgridApi;
 
-    public MissedCalls(Api api) {
-        this.api = api;
+    public MissedCalls(VoipgridApi voipgridApi) {
+        this.mVoipgridApi = voipgridApi;
     }
 
     /**
@@ -62,9 +62,9 @@ public class MissedCalls {
      */
     private Call<VoipGridResponse<CallRecord>> createHttpCall(boolean fetchCallsFromEntireAccount) {
         if (fetchCallsFromEntireAccount) {
-            return api.getRecentCalls(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+            return mVoipgridApi.getRecentCalls(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
         } else {
-            return api.getRecentCallsForLoggedInUser(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
+            return mVoipgridApi.getRecentCallsForLoggedInUser(NUMBER_OF_RECORDS_TO_PARSE_FOR_MISSED_CALLS, 0, CallRecord.getLimitDate());
         }
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
@@ -9,15 +9,13 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telephony.TelephonyManager;
 
-import com.github.tamir7.contacts.Contact;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.InternalNumbers;
 import com.voipgrid.vialer.api.models.PhoneAccount;
@@ -28,7 +26,6 @@ import com.voipgrid.vialer.calling.CallActivityHelper;
 import com.voipgrid.vialer.calling.CallNotifications;
 import com.voipgrid.vialer.callrecord.CachedContacts;
 import com.voipgrid.vialer.callrecord.CallRecordAdapter;
-import com.voipgrid.vialer.callrecord.CallRecordDataSource;
 import com.voipgrid.vialer.callrecord.CallRecordDataSourceFactory;
 import com.voipgrid.vialer.callrecord.MissedCalls;
 import com.voipgrid.vialer.callrecord.MissedCallsAdapter;
@@ -86,13 +83,11 @@ public class VialerModule {
         return new ConnectivityHelper(connectivityManager, telephonyManager);
     }
 
-    @Provides
-    SystemUser provideSystemUser(JsonStorage jsonStorage) {
+    @Provides SystemUser provideSystemUser(JsonStorage jsonStorage) {
         return (SystemUser) jsonStorage.get(SystemUser.class);
     }
 
-    @Provides @Nullable
-    PhoneAccount providePhoneAccount(JsonStorage jsonStorage) {
+    @Provides @Nullable PhoneAccount providePhoneAccount(JsonStorage jsonStorage) {
         return (PhoneAccount) jsonStorage.get(PhoneAccount.class);
     }
 
@@ -101,13 +96,11 @@ public class VialerModule {
         return (UserDestination) jsonStorage.get(UserDestination.class);
     }
 
-    @Provides @Nullable
-    InternalNumbers provideInternalNumbers(JsonStorage jsonStorage) {
+    @Provides @Nullable InternalNumbers provideInternalNumbers(JsonStorage jsonStorage) {
         return (InternalNumbers) jsonStorage.get(InternalNumbers.class);
     }
 
-    @Provides
-    LocalBroadcastManager provideLocalBroadcastManager(Context context) {
+    @Provides LocalBroadcastManager provideLocalBroadcastManager(Context context) {
         return LocalBroadcastManager.getInstance(context);
     }
 
@@ -116,13 +109,11 @@ public class VialerModule {
         return new BroadcastReceiverManager(localBroadcastManager, context);
     }
 
-    @Provides
-    AnalyticsHelper provideAnalyticsHelper() {
+    @Provides AnalyticsHelper provideAnalyticsHelper() {
         return new AnalyticsHelper(mVialerApplication.getDefaultTracker());
     }
 
-    @Provides
-    NotificationHelper provideNotificationHelper(Context context) {
+    @Provides NotificationHelper provideNotificationHelper(Context context) {
         return NotificationHelper.getInstance(context);
     }
 
@@ -136,23 +127,19 @@ public class VialerModule {
         return (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
     }
 
-    @Provides
-    Contacts provideContacts() {
+    @Provides Contacts provideContacts() {
         return new Contacts();
     }
 
-    @Provides
-    Preferences providePreferences(Context context) {
+    @Provides Preferences providePreferences(Context context) {
         return new Preferences(context);
     }
 
-    @Provides
-    CallActivityHelper provideCallActivityHelper(Contacts contacts) {
+    @Provides CallActivityHelper provideCallActivityHelper(Contacts contacts) {
         return new CallActivityHelper(contacts);
     }
 
-    @Provides
-    IpSwitchMonitor provideIpSwitchMonitor() {
+    @Provides IpSwitchMonitor provideIpSwitchMonitor() {
         return new IpSwitchMonitor();
     }
 
@@ -161,29 +148,24 @@ public class VialerModule {
         return new SipConfig(preferences, ipSwitchMonitor, broadcastReceiverManager);
     }
 
-    @Provides
-    SharedPreferences provideSharedPreferences(Context context) {
+    @Provides SharedPreferences provideSharedPreferences(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context);
     }
 
-    @Provides
-    ReachabilityReceiver provideReachabilityReceiver(Context context) {
+    @Provides ReachabilityReceiver provideReachabilityReceiver(Context context) {
         return new ReachabilityReceiver(context);
     }
 
-    @Provides
-    NetworkUtil provideNetworkUtil(Context context) {
+    @Provides NetworkUtil provideNetworkUtil(Context context) {
         return new NetworkUtil(context);
     }
 
-    @Provides
-    Api provideApi(Context context) {
+    @Provides VoipgridApi provideApi(Context context) {
         return ServiceGenerator.createApiService(context);
     }
 
-    @Provides
-    CallRecordDataSourceFactory provideCallRecordDataSourceFactory(Api api) {
-        return new CallRecordDataSourceFactory(api);
+    @Provides CallRecordDataSourceFactory provideCallRecordDataSourceFactory(VoipgridApi voipgridApi) {
+        return new CallRecordDataSourceFactory(voipgridApi);
     }
 
     @Provides
@@ -195,9 +177,8 @@ public class VialerModule {
         return new CachedContacts(contacts);
     }
 
-    @Provides
-    MissedCalls provideMissedCalls(Api api) {
-        return new MissedCalls(api);
+    @Provides MissedCalls provideMissedCalls(VoipgridApi voipgridApi) {
+        return new MissedCalls(voipgridApi);
     }
 
     @Provides MissedCallsAdapter provideMissedCallsAdapter(CachedContacts cachedContacts) {

--- a/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
+++ b/app/src/main/java/com/voipgrid/vialer/dagger/VialerModule.java
@@ -3,7 +3,9 @@ package com.voipgrid.vialer.dagger;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.media.AudioManager;
 import android.net.ConnectivityManager;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.Nullable;
@@ -21,6 +23,7 @@ import com.voipgrid.vialer.api.models.InternalNumbers;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SystemUser;
 import com.voipgrid.vialer.api.models.UserDestination;
+import com.voipgrid.vialer.call.NativeCallManager;
 import com.voipgrid.vialer.calling.CallActivityHelper;
 import com.voipgrid.vialer.calling.CallNotifications;
 import com.voipgrid.vialer.callrecord.CachedContacts;
@@ -30,9 +33,12 @@ import com.voipgrid.vialer.callrecord.CallRecordDataSourceFactory;
 import com.voipgrid.vialer.callrecord.MissedCalls;
 import com.voipgrid.vialer.callrecord.MissedCallsAdapter;
 import com.voipgrid.vialer.contacts.Contacts;
+import com.voipgrid.vialer.dialer.ToneGenerator;
 import com.voipgrid.vialer.reachability.ReachabilityReceiver;
 import com.voipgrid.vialer.sip.IpSwitchMonitor;
+import com.voipgrid.vialer.sip.NetworkConnectivity;
 import com.voipgrid.vialer.sip.SipConfig;
+import com.voipgrid.vialer.sip.SipConstants;
 import com.voipgrid.vialer.util.BroadcastReceiverManager;
 import com.voipgrid.vialer.util.ConnectivityHelper;
 import com.voipgrid.vialer.util.JsonStorage;
@@ -196,5 +202,21 @@ public class VialerModule {
 
     @Provides MissedCallsAdapter provideMissedCallsAdapter(CachedContacts cachedContacts) {
         return new MissedCallsAdapter(cachedContacts);
+    }
+
+    @Provides Handler provideHandler() {
+        return new Handler();
+    }
+
+    @Provides NativeCallManager provideNativeCallManager(TelephonyManager telephonyManager) {
+        return new NativeCallManager(telephonyManager);
+    }
+
+    @Provides ToneGenerator provideToneGenerator() {
+        return new ToneGenerator(AudioManager.STREAM_VOICE_CALL, SipConstants.RINGING_VOLUME);
+    }
+
+    @Provides NetworkConnectivity provideNetworkConnectivity() {
+        return new NetworkConnectivity();
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
+++ b/app/src/main/java/com/voipgrid/vialer/fcm/FcmMessagingService.java
@@ -13,7 +13,7 @@ import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
-import com.voipgrid.vialer.api.Registration;
+import com.voipgrid.vialer.api.Middleware;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.logging.LogHelper;
 import com.voipgrid.vialer.logging.Logger;
@@ -239,9 +239,9 @@ public class FcmMessagingService extends FirebaseMessagingService {
      */
     private void replyServer(RemoteMessageData remoteMessageData, boolean isAvailable) {
         mRemoteLogger.d("replyServer");
-        Registration registrationApi = ServiceGenerator.createRegistrationService(this);
+        Middleware middlewareApi = ServiceGenerator.createRegistrationService(this);
 
-        Call<ResponseBody> call = registrationApi.reply(remoteMessageData.getRequestToken(), isAvailable, remoteMessageData.getMessageStartTime());
+        Call<ResponseBody> call = middlewareApi.reply(remoteMessageData.getRequestToken(), isAvailable, remoteMessageData.getMessageStartTime());
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(@NonNull Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {

--- a/app/src/main/java/com/voipgrid/vialer/middleware/MiddlewareHelper.java
+++ b/app/src/main/java/com/voipgrid/vialer/middleware/MiddlewareHelper.java
@@ -12,7 +12,7 @@ import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
-import com.voipgrid.vialer.api.Registration;
+import com.voipgrid.vialer.api.Middleware;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SystemUser;
@@ -97,7 +97,7 @@ public class MiddlewareHelper {
             return;
         }
 
-        Registration api = ServiceGenerator.createRegistrationService(context);
+        Middleware api = ServiceGenerator.createRegistrationService(context);
 
         String sipUserId = ((PhoneAccount) jsonStorage.get(PhoneAccount.class)).getAccountId();
         String fullName = ((SystemUser) jsonStorage.get(SystemUser.class)).getFullName();
@@ -153,7 +153,7 @@ public class MiddlewareHelper {
             JsonStorage jsonStorage = new JsonStorage(context);
             AccountHelper accountHelper = new AccountHelper(context);
 
-            Registration api = ServiceGenerator.createRegistrationService(context);
+            Middleware api = ServiceGenerator.createRegistrationService(context);
             String sipUserId = ((PhoneAccount) jsonStorage.get(PhoneAccount.class)).getAccountId();
             String appName = context.getPackageName();
 

--- a/app/src/main/java/com/voipgrid/vialer/onboarding/SetUpVoipAccountFragment.java
+++ b/app/src/main/java/com/voipgrid/vialer/onboarding/SetUpVoipAccountFragment.java
@@ -10,7 +10,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import com.voipgrid.vialer.R;
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.PhoneAccount;
 import com.voipgrid.vialer.api.models.SystemUser;
@@ -28,7 +28,7 @@ public class SetUpVoipAccountFragment extends OnboardingFragment implements
         View.OnClickListener, Callback {
 
     private AccountHelper mAccountHelper;
-    private Api mApi;
+    private VoipgridApi mVoipgridApi;
     private Context mContext;
     private FragmentInteractionListener mListener;
     private JsonStorage mJsonStorage;
@@ -64,7 +64,7 @@ public class SetUpVoipAccountFragment extends OnboardingFragment implements
         mAccountHelper = new AccountHelper(mContext);
 
         mSystemUser = (SystemUser) mJsonStorage.get(SystemUser.class);
-        mApi = ServiceGenerator.createApiService(getActivity());
+        mVoipgridApi = ServiceGenerator.createApiService(getActivity());
 
         mVoipAccountButton = (Button) view.findViewById(R.id.set_voip_account_button);
         mVoipAccountButton.setOnClickListener(this);
@@ -136,7 +136,7 @@ public class SetUpVoipAccountFragment extends OnboardingFragment implements
             String phoneAccountId = mSystemUser.getPhoneAccountId();
             if (phoneAccountId != null) {
                 // Request new phoneaccount object.
-                Call<PhoneAccount> apicall = mApi.phoneAccount(phoneAccountId);
+                Call<PhoneAccount> apicall = mVoipgridApi.phoneAccount(phoneAccountId);
                 apicall.enqueue(this);
             } else {
                 // User has no phone account linked so remove it from the local storage.
@@ -153,8 +153,8 @@ public class SetUpVoipAccountFragment extends OnboardingFragment implements
     }
 
     private void requestSystemUser() {
-        mApi = ServiceGenerator.createApiService(mContext);
-        Call<SystemUser> call = mApi.systemUser();
+        mVoipgridApi = ServiceGenerator.createApiService(mContext);
+        Call<SystemUser> call = mVoipgridApi.systemUser();
         call.enqueue(this);
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/onboarding/SetupActivity.java
+++ b/app/src/main/java/com/voipgrid/vialer/onboarding/SetupActivity.java
@@ -13,12 +13,12 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
-import com.voipgrid.vialer.AccountActivity;
+import com.voipgrid.vialer.SettingsActivity;
 import com.voipgrid.vialer.MainActivity;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.WebActivityHelper;
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.ApiTokenFetcher;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.MobileNumber;
@@ -55,7 +55,7 @@ public class SetupActivity extends RemoteLoggingActivity implements
     private String mPassword;
     private String mActivityToReturnToName = "";
 
-    private Api mApi;
+    private VoipgridApi mVoipgridApi;
     private JsonStorage mJsonStorage;
     private Preferences mPreferences;
     private Logger mLogger;
@@ -172,9 +172,9 @@ public class SetupActivity extends RemoteLoggingActivity implements
     public void onUpdateMobileNumber(Fragment fragment, String mobileNumber) {
         enableProgressBar(true);
 
-        mApi = ServiceGenerator.createApiService(this);
+        mVoipgridApi = ServiceGenerator.createApiService(this);
 
-        Call<MobileNumber> call = mApi.mobileNumber(new MobileNumber(mobileNumber));
+        Call<MobileNumber> call = mVoipgridApi.mobileNumber(new MobileNumber(mobileNumber));
         call.enqueue(this);
     }
 
@@ -191,7 +191,7 @@ public class SetupActivity extends RemoteLoggingActivity implements
         String phoneAccountId = systemUser.getPhoneAccountId();
 
         if (phoneAccountId != null) {
-            Call<PhoneAccount> call = mApi.phoneAccount(phoneAccountId);
+            Call<PhoneAccount> call = mVoipgridApi.phoneAccount(phoneAccountId);
             call.enqueue(this);
         } else {
             enableProgressBar(false);
@@ -218,11 +218,11 @@ public class SetupActivity extends RemoteLoggingActivity implements
 
     @Override
     public void onFinish(Fragment fragment) {
-        if (mActivityToReturnToName.equals(AccountActivity.class.getSimpleName())){
+        if (mActivityToReturnToName.equals(SettingsActivity.class.getSimpleName())){
             PhoneAccountHelper phoneAccountHelper = new PhoneAccountHelper(this);
             phoneAccountHelper.savePhoneAccountAndRegister(
                     (PhoneAccount) mJsonStorage.get(PhoneAccount.class));
-            Intent intent = new Intent(this, AccountActivity.class);
+            Intent intent = new Intent(this, SettingsActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
             startActivity(intent);
         } else {
@@ -290,8 +290,8 @@ public class SetupActivity extends RemoteLoggingActivity implements
     }
 
     private void resetPassword(String email) {
-        Api api = ServiceGenerator.createApiService(this, null, null, null);
-        Call<Void> call = api.resetPassword(new PasswordResetParams(email));
+        VoipgridApi voipgridApi = ServiceGenerator.createApiService(this, null, null, null);
+        Call<Void> call = voipgridApi.resetPassword(new PasswordResetParams(email));
         call.enqueue(new Callback<Void>() {
             @Override
             public void onResponse(Call<Void> call, Response<Void> response) {
@@ -448,7 +448,7 @@ public class SetupActivity extends RemoteLoggingActivity implements
         enableProgressBar(true);
         enableProgressBar(true);
 
-        mApi = ServiceGenerator.createApiService(this, mUsername, mPassword, null);
+        mVoipgridApi = ServiceGenerator.createApiService(this, mUsername, mPassword, null);
 
         ApiTokenFetcher
                 .forCredentials(this, mUsername, mPassword)
@@ -470,7 +470,7 @@ public class SetupActivity extends RemoteLoggingActivity implements
         Intent intent = new Intent(fromActivity, SetupActivity.class);
         Bundle b = new Bundle();
         b.putInt("fragment", R.id.fragment_voip_account_missing);
-        b.putString("activity", AccountActivity.class.getSimpleName());
+        b.putString("activity", SettingsActivity.class.getSimpleName());
         intent.putExtras(b);
 
         fromActivity.startActivity(intent);
@@ -490,9 +490,9 @@ public class SetupActivity extends RemoteLoggingActivity implements
             AccountHelper accountHelper = new AccountHelper(SetupActivity.this);
             accountHelper.setCredentials(mUsername, mPassword, apiToken);
 
-            mApi = ServiceGenerator.createApiService(SetupActivity.this);
+            mVoipgridApi = ServiceGenerator.createApiService(SetupActivity.this);
 
-            Call<SystemUser> call2 = mApi.systemUser();
+            Call<SystemUser> call2 = mVoipgridApi.systemUser();
             call2.enqueue(SetupActivity.this);
         }
 

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipBroadcaster.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipBroadcaster.java
@@ -6,12 +6,12 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 /**
  * Helper class for sending broadcasts from background SIP classes to listening activities.
  */
-public class SipBroadcaster {
+class SipBroadcaster {
     private LocalBroadcastManager mBroadcastManager;
 
     private SipService mSipService;
 
-    public SipBroadcaster(SipService sipService) {
+    SipBroadcaster(SipService sipService) {
         mSipService = sipService;
         setUp();
     }
@@ -20,20 +20,20 @@ public class SipBroadcaster {
         mBroadcastManager = LocalBroadcastManager.getInstance(mSipService);
     }
 
-    public void broadcastServiceInfo(String info) {
+    void broadcastServiceInfo(String info) {
         Intent intent = new Intent(SipConstants.ACTION_BROADCAST_SERVICE_INFO);
         intent.putExtra(SipConstants.SERVICE_INFO_KEY, info);
         mBroadcastManager.sendBroadcast(intent);
     }
 
-    public void broadcastCallStatus(String identifier, String status) {
+    void broadcastCallStatus(String identifier, String status) {
         Intent intent = new Intent(SipConstants.ACTION_BROADCAST_CALL_STATUS);
         intent.putExtra(SipConstants.CALL_IDENTIFIER_KEY, identifier);
         intent.putExtra(SipConstants.CALL_STATUS_KEY, status);
         mBroadcastManager.sendBroadcast(intent);
     }
 
-    public void broadcastMissedCalls(SipConstants.CallMissedReason reason) {
+    void broadcastMissedCalls(SipConstants.CallMissedReason reason) {
         Intent intent = new Intent(SipConstants.ACTION_BROADCAST_CALL_MISSED);
         intent.putExtra(SipConstants.CALL_MISSED_KEY, reason);
         mBroadcastManager.sendBroadcast(intent);

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipCall.java
@@ -177,12 +177,11 @@ public class SipCall extends org.pjsip.pjsua2.Call {
     }
 
     public int getCallDuration() {
-        TimeVal timeVal = new TimeVal();
         try {
             CallInfo callInfo = this.getInfo();
             return callInfo.getConnectDuration().getSec();
         } catch (Exception e) {
-            return timeVal.getSec();
+            return -1;
         }
     }
 

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipConfig.java
@@ -16,7 +16,7 @@ import com.voipgrid.vialer.R;
 import com.voipgrid.vialer.VialerApplication;
 import com.voipgrid.vialer.analytics.AnalyticsApplication;
 import com.voipgrid.vialer.analytics.AnalyticsHelper;
-import com.voipgrid.vialer.api.Registration;
+import com.voipgrid.vialer.api.Middleware;
 import com.voipgrid.vialer.api.SecureCalling;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.PhoneAccount;
@@ -45,8 +45,6 @@ import org.pjsip.pjsua2.pj_log_decoration;
 import org.pjsip.pjsua2.pjmedia_srtp_use;
 import org.pjsip.pjsua2.pjsip_transport_type_e;
 import org.pjsip.pjsua2.pjsua_call_flag;
-
-import java.util.Map;
 
 import okhttp3.ResponseBody;
 import retrofit2.Callback;
@@ -400,7 +398,7 @@ public class SipConfig implements AccountStatus {
                 ((AnalyticsApplication) mSipService.getApplication()).getDefaultTracker()
         );
 
-        Registration registrationApi = ServiceGenerator.createRegistrationService(mSipService);
+        Middleware middlewareApi = ServiceGenerator.createRegistrationService(mSipService);
 
         String analyticsLabel = ConnectivityHelper.get(mSipService).getAnalyticsLabel();
 
@@ -421,7 +419,7 @@ public class SipConfig implements AccountStatus {
                 startUpTime
         );
 
-        retrofit2.Call<ResponseBody> call = registrationApi.reply(token, true, messageStartTime);
+        retrofit2.Call<ResponseBody> call = middlewareApi.reply(token, true, messageStartTime);
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(@NonNull retrofit2.Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {

--- a/app/src/main/java/com/voipgrid/vialer/sip/SipService.java
+++ b/app/src/main/java/com/voipgrid/vialer/sip/SipService.java
@@ -1,5 +1,8 @@
 package com.voipgrid.vialer.sip;
 
+import static com.voipgrid.vialer.sip.SipConstants.ACTION_CALL_INCOMING;
+import static com.voipgrid.vialer.sip.SipConstants.ACTION_CALL_OUTGOING;
+
 import android.app.NotificationManager;
 import android.app.Service;
 import android.content.BroadcastReceiver;
@@ -40,31 +43,7 @@ import javax.inject.Inject;
  * provides a persistent interface to SIP services throughout the app.
  *
  */
-public class SipService extends Service implements SipConfig.Listener {
-    private final IBinder mBinder = new SipServiceBinder();
-
-    private Handler mHandler;
-    private Intent mIncomingCallDetails = null;
-    private ToneGenerator mToneGenerator;
-    private NetworkConnectivity mNetworkConnectivity = new NetworkConnectivity();
-
-    private Preferences mPreferences;
-    private Logger mLogger;
-    private SipBroadcaster mSipBroadcaster;
-    private SipCall mCurrentCall;
-    private SipCall mInitialCall;
-    private NativeCallManager mNativeCallManager;
-
-    private List<SipCall> mCallList = new ArrayList<>();
-    private String mInitialCallType;
-
-    private static final int CHECK_SERVICE_USER_INTERVAL_MS = 20000;
-    private Handler mCheckServiceHandler;
-    private Runnable mCheckServiceRunnable;
-    @Nullable private Intent mIntent;
-
-    @Inject SipConfig mSipConfig;
-    @Inject protected BroadcastReceiverManager mBroadcastReceiverManager;
+public class SipService extends Service {
 
     /**
      * This will track whether this instance of SipService has ever handled a call,
@@ -73,71 +52,33 @@ public class SipService extends Service implements SipConfig.Listener {
      */
     private boolean mSipServiceHasHandledACall = false;
 
-    private final BroadcastReceiver phoneStateReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            try {
-                String phoneState = intent.getStringExtra(TelephonyManager.EXTRA_STATE);
-
-                if (!phoneState.equals(TelephonyManager.EXTRA_STATE_OFFHOOK)) {
-                    return;
-                }
-
-                // When the native call has been picked up and there is a current call in the ringing state
-                // Then decline the current call.
-                mLogger.e("Native call is picked up.");
-                mLogger.e("Is there an active call: " + (mCurrentCall != null));
-
-                if (mCurrentCall == null) {
-                    return;
-                }
-
-                mLogger.e("Current call state: " + mCurrentCall.getCurrentCallState());
-
-                if (mCurrentCall.isCallRinging() || mCurrentCall.getCurrentCallState().equals(SipConstants.CALL_INVALID_STATE)) {
-                    mLogger.e("Our call is still ringing. So decline it.");
-                    mCurrentCall.decline();
-                    return;
-                }
-
-                if (mCurrentCall.isConnected() && !mCurrentCall.isOnHold()) {
-                    mLogger.e("Call was not on hold already. So put call on hold.");
-                    mCurrentCall.toggleHold();
-                }
-            } catch(Exception e) {
-                e.printStackTrace();
-            }
-        }
-    };
-
     /**
      * Set when the SipService is active. This is used to respond to the middleware.
      */
     public static boolean sipServiceActive = false;
 
-    /**
-     * Class the be able to bind a activity to this service.
-     */
-    public class SipServiceBinder extends Binder {
-        public SipService getService() {
-            // Return this instance of SipService so clients can call public methods.
-            return SipService.this;
-        }
-    }
+    private Intent mIncomingCallDetails = null;
+    private SipCall mCurrentCall;
+    private SipCall mInitialCall;
+    private List<SipCall> mCallList = new ArrayList<>();
+    private String mInitialCallType;
 
-    /**
-     * SIP does not present Media by default.
-     * Use Android's ToneGenerator to play a dial tone at certain required times.
-     * @see for usage of delayed "mRingbackRunnable" callback.
-     */
-    private Runnable mRingbackRunnable = new Runnable() {
-        @Override
-        public void run() {
-            // Play a ring back tone to update a user that setup is ongoing.
-            mToneGenerator.startTone(ToneGenerator.Constants.TONE_SUP_DIAL, 1000);
-            mHandler.postDelayed(mRingbackRunnable, 4000);
-        }
-    };
+    @Nullable private Intent mIntent;
+
+    private Logger mLogger;
+    private SipBroadcaster mSipBroadcaster;
+    private final BroadcastReceiver phoneStateReceiver = new PhoneStateReceiver();
+    private Runnable mRingbackRunnable = new OutgoingCallRinger();
+    private final IBinder mBinder = new SipServiceBinder();
+    private CheckServiceIsRunning mCheckService = new CheckServiceIsRunning();
+    @Inject protected SipConfig mSipConfig;
+    @Inject protected BroadcastReceiverManager mBroadcastReceiverManager;
+    @Inject protected Handler mHandler;
+    @Inject protected Preferences mPreferences;
+    @Inject protected ToneGenerator mToneGenerator;
+    @Inject protected NetworkConnectivity mNetworkConnectivity;
+    @Inject protected NativeCallManager mNativeCallManager;
+    @Inject @Nullable protected PhoneAccount mPhoneAccount;
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -147,77 +88,105 @@ public class SipService extends Service implements SipConfig.Listener {
     @Override
     public void onCreate() {
         super.onCreate();
+        mLogger = new Logger(SipService.class);
+        mSipBroadcaster = new SipBroadcaster(this);
         VialerApplication.get().component().inject(this);
         AudioStateChangeReceiver.fetch();
-
-        mHandler = new Handler();
-
-        mToneGenerator = new ToneGenerator(
-                AudioManager.STREAM_VOICE_CALL,
-                SipConstants.RINGING_VOLUME);
-
-        mSipBroadcaster = new SipBroadcaster(this);
-
-        mPreferences = new Preferences(this);
-        mLogger = new Logger(SipService.class);
-        mNativeCallManager = new NativeCallManager((TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE));
-
         mLogger.d("onCreate");
 
         mBroadcastReceiverManager.registerReceiverViaGlobalBroadcastManager(phoneStateReceiver, TelephonyManager.ACTION_PHONE_STATE_CHANGED);
         mBroadcastReceiverManager.registerReceiverViaGlobalBroadcastManager(mNetworkConnectivity, ConnectivityManager.CONNECTIVITY_ACTION);
+        mCheckService.start();
+    }
 
-        // Create runnable to check if the SipService is still in use.
-        mCheckServiceHandler = new Handler();
-        mCheckServiceRunnable = new Runnable() {
-            @Override
-            public void run() {
-                // Check if the service is being used after 10 seconds and shutdown the service
-                // if required.
-                checkServiceBeingUsed();
-                mCheckServiceHandler.postDelayed(this, CHECK_SERVICE_USER_INTERVAL_MS);
-            }
-        };
-        mCheckServiceHandler.postDelayed(mCheckServiceRunnable, CHECK_SERVICE_USER_INTERVAL_MS);
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        mLogger.i("mSipServiceHasHandledACall: " + mSipServiceHasHandledACall);
 
-        PhoneAccount phoneAccount = new JsonStorage<PhoneAccount>(this).get(PhoneAccount.class);
-        if (phoneAccount != null) {
-            // Try to load PJSIP library.
-            mSipConfig = mSipConfig.init(this, phoneAccount);
-            mSipConfig.initLibrary(this);
-        } else {
-            // User has no sip account so destroy the service.
+        // If the SipService has already handled a call but now has no call, this suggests
+        // that the SipService is stuck not doing anything so it should be immediately shut
+        // down.
+        if (mSipServiceHasHandledACall && mCurrentCall == null) {
+            mLogger.i("onStartCommand was triggered after a call has already been handled but with no current call, stopping SipService...");
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+
+        handleCallDeclineIntentIfAppropriate();
+
+        initialiseCallBasedOnIntent(intent);
+
+        return START_NOT_STICKY;
+    }
+
+    /**
+     * Initialise the call based on the information in the intent.
+     *
+     * @param intent
+     */
+    public void initialiseCallBasedOnIntent(Intent intent) {
+        if (intent == null) return;
+
+        mIntent = intent;
+        mInitialCallType = mIntent.getAction();
+
+        if (ACTION_CALL_INCOMING.equals(mInitialCallType)) {
+            initialiseIncomingCall();
+        }
+        else if (ACTION_CALL_OUTGOING.equals(mInitialCallType)) {
+            initialiseOutgoingCall(intent);
+        }
+        else {
+            mLogger.e("Stopping SipService as an intent with no action was received");
+            stopSelf();
+        }
+    }
+
+    /**
+     * Perform necessary steps to initialise an incoming call.
+     *
+     */
+    private void initialiseIncomingCall() {
+        mLogger.d("incomingCall");
+        mIncomingCallDetails = mIntent;
+        loadSip();
+    }
+
+    /**
+     * Perform necessary steps to initialise an outgoing call.
+     *
+     */
+    private void initialiseOutgoingCall(Intent intent) {
+        mLogger.d("outgoingCall");
+        loadSip();
+        makeCall(
+                intent.getData(),
+                mIntent.getStringExtra(SipConstants.EXTRA_CONTACT_NAME),
+                mIntent.getStringExtra(SipConstants.EXTRA_PHONE_NUMBER),
+                true
+        );
+    }
+
+    /**
+     * Begin the process of actually starting the SIP library so we can
+     * start/receive calls.
+     *
+     */
+    private void loadSip() {
+        if (mPhoneAccount == null) {
             mLogger.w("No sip account when trying to create service");
             stopSelf();
+            return;
         }
-    }
 
-    private void checkServiceBeingUsed() {
-        mLogger.d("checkServiceBeingUsed");
-        if (mCurrentCall == null) {
-            mLogger.i("No active calls stop the service");
+        try {
+            mLogger.i("Attempting to load sip lib");
+            mSipConfig = mSipConfig.init(this, mPhoneAccount);
+            mSipConfig.initLibrary();
+        } catch (Exception e) {
+            mLogger.e("Failed to load pjsip, stopping the service");
             stopSelf();
         }
-    }
-
-    public Logger getLogger() {
-        return mLogger;
-    }
-
-    public Preferences getPreferences() {
-        return mPreferences;
-    }
-
-    public NativeCallManager getNativeCallManager() {
-        return mNativeCallManager;
-    }
-
-    public String getInitialCallType() {
-        return mInitialCallType;
-    }
-
-    public SipConfig getSipConfig() {
-        return mSipConfig;
     }
 
     @Override
@@ -238,88 +207,32 @@ public class SipService extends Service implements SipConfig.Listener {
             mLogger.w("Trying to unregister phoneStateReceiver not registered.");
         }
 
-        mCheckServiceHandler.removeCallbacks(mCheckServiceRunnable);
+        mHandler.removeCallbacks(mCheckService);
 
         sipServiceActive = false;
         super.onDestroy();
     }
 
-    boolean pjSipLoaded = false;
+    /**
+     * We will also handle an intent that is telling us to decline the incoming call,
+     * this intent is currently sent when the user presses decline on the call
+     * notification as there is no activity to defer to, it must be handled here.
+     *
+     */
+    private void handleCallDeclineIntentIfAppropriate() {
+        if (mIntent == null || mIntent.getType() == null) return;
 
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        mLogger.d("onStartCommand");
-        mLogger.i("onStartCommand mSipServiceHasHandledACall: " + mSipServiceHasHandledACall);
+        if (!mIntent.getType().equals(SipConstants.CALL_DECLINE_INCOMING_CALL)) return;
 
-        // If the SipService has already handled a call but now has no call, this suggests
-        // that the SipService is stuck not doing anything so it should be immediately shut
-        // down.
-        if (mSipServiceHasHandledACall && mCurrentCall == null) {
-            mLogger.i("onStartCommand was triggered after a call has already been handled but with no current call, stopping SipService...");
+        try {
+            mLogger.i("Attempting to decline a call based on the intent type broadcast to the SipService");
+            mCurrentCall.decline();
+            NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            notificationManager.cancelAll();
             stopSelf();
-            return START_NOT_STICKY;
+        } catch(Exception e) {
+            e.printStackTrace();
         }
-
-        mIntent = intent;
-
-        if (pjSipLoaded) {
-            pjSipDidLoad();
-        }
-
-        return START_NOT_STICKY;
-    }
-
-    @Override
-    public void pjSipDidLoad() {
-        pjSipLoaded = true;
-
-        if (mIntent == null) {
-            return;
-        }
-
-        mInitialCallType = mIntent.getAction();
-        Uri number = mIntent.getData();
-
-        switch (mInitialCallType) {
-            case SipConstants.ACTION_CALL_INCOMING:
-                mLogger.d("incomingCall");
-                mIncomingCallDetails = mIntent;
-                break;
-            case SipConstants.ACTION_CALL_OUTGOING:
-                mLogger.d("outgoingCall");
-                makeCall(
-                        number,
-                        mIntent.getStringExtra(SipConstants.EXTRA_CONTACT_NAME),
-                        mIntent.getStringExtra(SipConstants.EXTRA_PHONE_NUMBER),
-                        true
-                );
-                break;
-            default:
-                stopSelf();
-        }
-
-        if (mIntent.getType() != null) {
-            if (mIntent.getType().equals(SipConstants.CALL_DECLINE_INCOMING_CALL)) {
-                try {
-                    mCurrentCall.decline();
-                    NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-                    notificationManager.cancelAll();
-                    stopSelf();
-                } catch(Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-    }
-
-    @Override
-    public void pjSipFailedToLoad(Exception e) {
-        mLogger.e("Unable to load pjsip: " + e.getClass().getSimpleName() + ": " + e.getMessage());
-        stopSelf();
-    }
-
-    public SipBroadcaster getSipBroadcaster() {
-        return mSipBroadcaster;
     }
 
     /**
@@ -474,6 +387,119 @@ public class SipService extends Service implements SipConfig.Listener {
             return mCallList.get(0);
         } else {
             return null;
+        }
+    }
+
+    public Logger getLogger() {
+        return mLogger;
+    }
+
+    public Preferences getPreferences() {
+        return mPreferences;
+    }
+
+    public NativeCallManager getNativeCallManager() {
+        return mNativeCallManager;
+    }
+
+    public String getInitialCallType() {
+        return mInitialCallType;
+    }
+
+    public SipConfig getSipConfig() {
+        return mSipConfig;
+    }
+
+    public SipBroadcaster getSipBroadcaster() {
+        return mSipBroadcaster;
+    }
+
+    /**
+     * Class the be able to bind a activity to this service.
+     */
+    public class SipServiceBinder extends Binder {
+        public SipService getService() {
+            // Return this instance of SipService so clients can call public methods.
+            return SipService.this;
+        }
+    }
+
+    private class PhoneStateReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            try {
+                String phoneState = intent.getStringExtra(TelephonyManager.EXTRA_STATE);
+
+                if (!phoneState.equals(TelephonyManager.EXTRA_STATE_OFFHOOK)) {
+                    return;
+                }
+
+                // When the native call has been picked up and there is a current call in the ringing state
+                // Then decline the current call.
+                mLogger.e("Native call is picked up.");
+                mLogger.e("Is there an active call: " + (mCurrentCall != null));
+
+                if (mCurrentCall == null) {
+                    return;
+                }
+
+                mLogger.e("Current call state: " + mCurrentCall.getCurrentCallState());
+
+                if (mCurrentCall.isCallRinging() || mCurrentCall.getCurrentCallState().equals(SipConstants.CALL_INVALID_STATE)) {
+                    mLogger.e("Our call is still ringing. So decline it.");
+                    mCurrentCall.decline();
+                    return;
+                }
+
+                if (mCurrentCall.isConnected() && !mCurrentCall.isOnHold()) {
+                    mLogger.e("Call was not on hold already. So put call on hold.");
+                    mCurrentCall.toggleHold();
+                }
+            } catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private class OutgoingCallRinger implements Runnable {
+        @Override
+        public void run() {
+            // Play a ring back tone to update a user that setup is ongoing.
+            mToneGenerator.startTone(ToneGenerator.Constants.TONE_SUP_DIAL, 1000);
+            mHandler.postDelayed(mRingbackRunnable, 4000);
+        }
+    }
+
+    /**
+     * Starting this runnable spawns an ongoing check every {@value #CHECK_SERVICE_USER_INTERVAL_MS}ms that will
+     * shutdown the service if there is no active call. This is a fallback to ensure the SipService is properly
+     * shut down after a call if for some reason it wasn't.
+     *
+     */
+    private class CheckServiceIsRunning implements Runnable {
+
+        /**
+         * The timeout between checks to determine the service is still running.
+         *
+         */
+        static final int CHECK_SERVICE_USER_INTERVAL_MS = 20000;
+
+        private void start() {
+            mHandler.postDelayed(mCheckService, CHECK_SERVICE_USER_INTERVAL_MS);
+        }
+
+        @Override
+        public void run() {
+            stopServiceIfNoActiveCalls();
+            mHandler.postDelayed(this, CHECK_SERVICE_USER_INTERVAL_MS);
+        }
+
+        private void stopServiceIfNoActiveCalls() {
+            mLogger.d("checkServiceBeingUsed");
+            if (mCurrentCall == null) {
+                mLogger.i("No active calls stop the service");
+                stopSelf();
+            }
         }
     }
 }

--- a/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
+++ b/app/src/main/java/com/voipgrid/vialer/statistics/VialerStatistics.java
@@ -56,13 +56,12 @@ import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_NETWORK_WIFI;
 import static com.voipgrid.vialer.statistics.StatsConstants.VALUE_OS;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
 import com.google.gson.GsonBuilder;
 import com.voipgrid.vialer.Preferences;
 import com.voipgrid.vialer.VialerApplication;
-import com.voipgrid.vialer.api.Registration;
+import com.voipgrid.vialer.api.Middleware;
 import com.voipgrid.vialer.api.SecureCalling;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.logging.Logger;
@@ -86,7 +85,7 @@ public class VialerStatistics {
     private final DefaultDataProvider mDefaultDataProvider;
     private final BluetoothDataProvider mBluetoothDataProvider;
     private final Logger mLogger;
-    private final Registration mRegistration;
+    private final Middleware mMiddleware;
 
     private Map<String, String> payload;
 
@@ -100,8 +99,8 @@ public class VialerStatistics {
         );
     }
 
-    private VialerStatistics(Preferences preferences, JsonStorage jsonStorage, Registration registration) {
-        mRegistration = registration;
+    private VialerStatistics(Preferences preferences, JsonStorage jsonStorage, Middleware middleware) {
+        mMiddleware = middleware;
         mLogger = new Logger(this.getClass());
         mDefaultDataProvider = new DefaultDataProvider(preferences, jsonStorage);
         mBluetoothDataProvider = new BluetoothDataProvider();
@@ -368,7 +367,7 @@ public class VialerStatistics {
     }
 
     private void send() {
-        mRegistration.metrics(payload).enqueue(new VialerStatisticsRequestCallback(mLogger));
+        mMiddleware.metrics(payload).enqueue(new VialerStatisticsRequestCallback(mLogger));
         log();
         resetPayload();
     }

--- a/app/src/main/java/com/voipgrid/vialer/util/NotificationHelper.java
+++ b/app/src/main/java/com/voipgrid/vialer/util/NotificationHelper.java
@@ -19,7 +19,7 @@ import android.os.Build;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.TaskStackBuilder;
 
-import com.voipgrid.vialer.AccountActivity;
+import com.voipgrid.vialer.SettingsActivity;
 import com.voipgrid.vialer.CallActivity;
 import com.voipgrid.vialer.MainActivity;
 import com.voipgrid.vialer.R;
@@ -284,7 +284,7 @@ public class NotificationHelper {
         // Create stack for the app to use when clicking the notification.
         TaskStackBuilder stackBuilder = TaskStackBuilder.create(mContext);
         stackBuilder.addParentStack(MainActivity.class);
-        stackBuilder.addNextIntent(new Intent(mContext, AccountActivity.class));
+        stackBuilder.addNextIntent(new Intent(mContext, SettingsActivity.class));
 
         mBuilder.setContentIntent(stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT));
 

--- a/app/src/main/java/com/voipgrid/vialer/util/PhoneAccountHelper.java
+++ b/app/src/main/java/com/voipgrid/vialer/util/PhoneAccountHelper.java
@@ -6,7 +6,7 @@ import android.content.Context;
 import android.os.AsyncTask;
 
 import com.voipgrid.vialer.Preferences;
-import com.voipgrid.vialer.api.Api;
+import com.voipgrid.vialer.api.VoipgridApi;
 import com.voipgrid.vialer.api.SecureCalling;
 import com.voipgrid.vialer.api.ServiceGenerator;
 import com.voipgrid.vialer.api.models.PhoneAccount;
@@ -24,7 +24,7 @@ import retrofit2.Response;
  */
 public class PhoneAccountHelper {
 
-    private Api mApi;
+    private VoipgridApi mVoipgridApi;
     private Context mContext;
     private Preferences mPreferences;
     private JsonStorage mJsonStorage;
@@ -37,7 +37,7 @@ public class PhoneAccountHelper {
         mJsonStorage = new JsonStorage(context);
         mSecureCalling = SecureCalling.fromContext(context);
 
-        mApi = ServiceGenerator.createApiService(mContext);
+        mVoipgridApi = ServiceGenerator.createApiService(mContext);
     }
 
     /**
@@ -45,7 +45,7 @@ public class PhoneAccountHelper {
      * @return
      */
     public SystemUser getAndUpdateSystemUser() {
-        Call<SystemUser> call = mApi.systemUser();
+        Call<SystemUser> call = mVoipgridApi.systemUser();
         SystemUser systemUser = (SystemUser) mJsonStorage.get(SystemUser.class);
         if (systemUser == null) {
             systemUser = null;
@@ -97,7 +97,7 @@ public class PhoneAccountHelper {
                 // If no PhoneAccountId is returned, remove current PhoneAccount information from jsonstorage.
                 new JsonStorage(mContext).remove(PhoneAccount.class);
 
-                Call<PhoneAccount> phoneAccountCall = mApi.phoneAccount(phoneAccountId);
+                Call<PhoneAccount> phoneAccountCall = mVoipgridApi.phoneAccount(phoneAccountId);
                 try {
                     Response<PhoneAccount> phoneAccountResponse = phoneAccountCall.execute();
                     if (phoneAccountResponse.isSuccessful() && phoneAccountResponse.body() != null) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -7,7 +7,7 @@
     android:focusable="true"
     android:focusableInTouchMode="true"
     android:orientation="vertical"
-    tools:context="com.voipgrid.vialer.AccountActivity">
+    tools:context="com.voipgrid.vialer.SettingsActivity">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/action_bar"

--- a/app/src/main/res/menu/menu_account.xml
+++ b/app/src/main/res/menu/menu_account.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.voipgrid.vialer.AccountActivity">
+    tools:context="com.voipgrid.vialer.SettingsActivity">
     <item android:id="@+id/action_edit" android:title="@string/action_edit"
         android:icon="@drawable/ic_mode_edit_white_18dp"
         android:visible="false"

--- a/app/src/main/res/xml/tracker.xml
+++ b/app/src/main/res/xml/tracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
     <string name="ga_trackingId">UA-60726618-4</string>
 
     <!-- Enable automatic Activity measurement -->
@@ -12,7 +12,7 @@
     <screenName name="com.voipgrid.vialer.onboarding.SetupActivity">
         Onboarding
     </screenName>
-    <screenName name="com.voipgrid.vialer.AccountActivity">
+    <screenName name="com.voipgrid.vialer.SettingsActivity">
         Settings
     </screenName>
     <screenName name="com.voipgrid.vialer.CallActivity">

--- a/app/src/verbonden/res/xml/tracker.xml
+++ b/app/src/verbonden/res/xml/tracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
 
     <string name="ga_trackingId">UA-79028801-2</string>
 
@@ -13,7 +13,7 @@
     <screenName name="com.voipgrid.vialer.onboarding.SetupActivity">
         Onboarding
     </screenName>
-    <screenName name="com.voipgrid.vialer.AccountActivity">
+    <screenName name="com.voipgrid.vialer.SettingsActivity">
         Settings
     </screenName>
     <screenName name="com.voipgrid.vialer.CallActivity">

--- a/app/src/voys/res/xml/tracker.xml
+++ b/app/src/voys/res/xml/tracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
     <string name="ga_trackingId">UA-401436-29</string>
 
     <!-- Enable automatic Activity measurement -->
@@ -12,7 +12,7 @@
     <screenName name="com.voipgrid.vialer.onboarding.SetupActivity">
         Onboarding
     </screenName>
-    <screenName name="com.voipgrid.vialer.AccountActivity">
+    <screenName name="com.voipgrid.vialer.SettingsActivity">
         Settings
     </screenName>
     <screenName name="com.voipgrid.vialer.CallActivity">

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.google.gms:google-services:4.2.0'
         classpath 'io.fabric.tools:gradle:1.26.1'
         classpath 'com.google.firebase:firebase-plugins:1.1.5'


### PR DESCRIPTION
This branch contains a lot of changed files as I refactored the name of Registration -> Middleware, Api -> VoipgridApi and AccountActivity -> SettingsActivity to better reflect what they are, and then all classes that use them had to be changed too, these changes aren't hugely important.

To resolve the issue mentioned in the ticket title I did a major refactor of SipService as it was encountering race conditions that meant it was failing depending on how quickly pjsip happened to load. I moved all pjsip related functionality out of the onCreate method, so this is now purely setup. Booting pjsip and initialising the SipService is all done on the onStartCommand, and it takes a slightly different path depending of this is an incoming/outgoing call.

I was also unaware that enabling OPUS required sending a request to the API, so this will now occur whenever we update the securecalling setting as it's all part of the same request. It will always be forced available because we specify a single codec to use so it should just be enabled all the time and then the app will determine which to actually use.